### PR TITLE
Bs 127 | Fix for multiple concepts having same concept source and reference term code with different map types

### DIFF
--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolver.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolver.java
@@ -87,7 +87,7 @@ public class TSConceptUuidResolver {
             logger.error("Concept Source " + conceptSystem + " not found");
             throw new APIException("Concept Source " + conceptSystem + " not found");
         }
-        Concept existingAnswerConcept = conceptService.getConceptByMapping(conceptReferenceTermCode, conceptSource.getName());
+        Concept existingAnswerConcept = getConceptByReferenceTermCodeAndConceptSource(conceptReferenceTermCode, conceptSource.getName());
         if (existingAnswerConcept == null) {
             return getNewAnswerConcept(conceptClassName, conceptSet, conceptDatatypeName, conceptReferenceTermCode, conceptSource);
         }
@@ -224,6 +224,13 @@ public class TSConceptUuidResolver {
 
     public Concept getConcept(String conceptName) {
         return conceptService.getConceptByName(conceptName);
+    }
+
+    public Concept getConceptByReferenceTermCodeAndConceptSource(String conceptReferenceTermCode, String conceptSourceName) {
+        List<Concept> conceptList = conceptService.getConceptsByMapping(conceptReferenceTermCode, conceptSourceName);
+        ConceptMapType sameAsConceptMapType = conceptService.getConceptMapTypeByUuid(ConceptMapType.SAME_AS_MAP_TYPE_UUID);
+        Optional<Concept> existingConcept = conceptList.stream().filter(concept -> concept.getConceptMappings().stream().anyMatch(conceptMapping -> (conceptMapping.getConceptReferenceTerm().getCode().equalsIgnoreCase(conceptReferenceTermCode) && conceptMapping.getConceptMapType().getName().equalsIgnoreCase(sameAsConceptMapType.getName())))).findFirst();
+        return existingConcept.orElse(null);
     }
 
 }

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/BahmniDiagnosisAnswerConceptSaveCommandTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/BahmniDiagnosisAnswerConceptSaveCommandTest.java
@@ -208,7 +208,7 @@ public class BahmniDiagnosisAnswerConceptSaveCommandTest {
     private List<BahmniDiagnosisRequest> createBahmniDiagnoses(String conceptSystem, boolean isCodedAnswerFromTermimologyServer) {
         String codedAnswerUuid = null;
         if (isCodedAnswerFromTermimologyServer) {
-            codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "61462000";
+            codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "dummyConceptCode";
         } else {
             codedAnswerUuid = "coded-answer-uuid";
         }
@@ -259,7 +259,7 @@ public class BahmniDiagnosisAnswerConceptSaveCommandTest {
         } else {
             mockConceptMapType = "narrowerThan";
         }
-        String mockReferenceTermCode = "61462000";
+        String mockReferenceTermCode = "dummyConceptCode";
         ConceptSource conceptSource = getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE);
 
         String mockConceptName = "dummyConcept";

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/BahmniDiagnosisAnswerConceptSaveCommandTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/BahmniDiagnosisAnswerConceptSaveCommandTest.java
@@ -8,7 +8,10 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.openmrs.Concept;
+import org.openmrs.ConceptMap;
+import org.openmrs.ConceptMapType;
 import org.openmrs.ConceptName;
+import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.ConceptSource;
 import org.openmrs.api.APIException;
 import org.openmrs.api.AdministrationService;
@@ -27,6 +30,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -137,7 +141,9 @@ public class BahmniDiagnosisAnswerConceptSaveCommandTest {
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
         BahmniEncounterTransaction bahmniEncounterTransaction = getBahmniEncounterTransaction(MOCK_CONCEPT_SYSTEM, true);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
-        when(conceptService.getConceptByMapping(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
+        List<Concept> mockConceptList = getMockConceptList(true);
+        when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConceptList);
+        when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
         when(conceptService.getConceptByUuid(UNCLASSIFIED_CONCEPT_SET_UUID)).thenReturn(unclassifiedConceptSet);
         when(terminologyLookupService.getConcept(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
@@ -243,5 +249,33 @@ public class BahmniDiagnosisAnswerConceptSaveCommandTest {
         concept.setFullySpecifiedName(fullySpecifiedName);
         concept.setSet(true);
         return concept;
+    }
+
+
+    private List<Concept> getMockConceptList(boolean isSameAs) {
+        String mockConceptMapType = "";
+        if (isSameAs) {
+            mockConceptMapType = "sameAs";
+        } else {
+            mockConceptMapType = "narrowerThan";
+        }
+        String mockReferenceTermCode = "61462000";
+        ConceptSource conceptSource = getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE);
+
+        String mockConceptName = "dummyConcept";
+        ConceptReferenceTerm conceptReferenceTerm = new ConceptReferenceTerm(conceptSource, mockReferenceTermCode, mockConceptName);
+        ConceptMapType conceptMapType = getMockConceptMapType(mockConceptMapType);
+        List<Concept> conceptList = new ArrayList<>();
+        Concept concept1 = getDiagnosisConcept();
+        ConceptMap conceptMap = new ConceptMap(conceptReferenceTerm, conceptMapType);
+        concept1.addConceptMapping(conceptMap);
+        conceptList.add(concept1);
+        return conceptList;
+    }
+
+    private ConceptMapType getMockConceptMapType(String name) {
+        ConceptMapType conceptMapType = new ConceptMapType();
+        conceptMapType.setName(name);
+        return conceptMapType;
     }
 }

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/BahmniObservationAnswerConceptSaveCommandTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/BahmniObservationAnswerConceptSaveCommandTest.java
@@ -9,7 +9,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
+import org.openmrs.ConceptMap;
+import org.openmrs.ConceptMapType;
 import org.openmrs.ConceptName;
+import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.ConceptSource;
 import org.openmrs.api.APIException;
 import org.openmrs.api.AdministrationService;
@@ -26,6 +29,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -136,7 +140,9 @@ public class BahmniObservationAnswerConceptSaveCommandTest {
         Concept mockConceptSet = getMockConceptSet();
         BahmniEncounterTransaction bahmniEncounterTransaction = getBahmniEncounterTransaction(MOCK_CONCEPT_SYSTEM, true, false);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(mockConceptSetUuid);
-        when(conceptService.getConceptByMapping(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
+        List<Concept> mockConceptList = getMockConceptList(true);
+        when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConceptList);
+        when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
         when(conceptService.getConceptByUuid(any())).thenReturn(mockConceptSet);
         when(terminologyLookupService.getConcept(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
@@ -160,7 +166,9 @@ public class BahmniObservationAnswerConceptSaveCommandTest {
         addNewAnswerToConceptSet(getMockAnswerConcept(), mockConceptSet);
         BahmniEncounterTransaction bahmniEncounterTransaction = getBahmniEncounterTransaction(MOCK_CONCEPT_SYSTEM, true, false);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(mockConceptSetUuid);
-        when(conceptService.getConceptByMapping(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
+        List<Concept> mockConceptList = getMockConceptList(true);
+        when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConceptList);
+        when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
         when(conceptService.getConceptByUuid(any())).thenReturn(mockConceptSet);
         when(terminologyLookupService.getConcept(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
@@ -292,5 +300,31 @@ public class BahmniObservationAnswerConceptSaveCommandTest {
         newConceptAnswer.setAnswerConcept(concept);
         conceptSet.addAnswer(newConceptAnswer);
         return conceptSet;
+    }
+    private List<Concept> getMockConceptList(boolean isSameAs) {
+        String mockConceptMapType = "";
+        if (isSameAs) {
+            mockConceptMapType = "sameAs";
+        } else {
+            mockConceptMapType = "narrowerThan";
+        }
+        String mockReferenceTermCode = "61462000";
+        ConceptSource conceptSource = getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE);
+
+        String mockConceptName = "dummyConcept";
+        ConceptReferenceTerm conceptReferenceTerm = new ConceptReferenceTerm(conceptSource, mockReferenceTermCode, mockConceptName);
+        ConceptMapType conceptMapType = getMockConceptMapType(mockConceptMapType);
+        List<Concept> conceptList = new ArrayList<>();
+        Concept concept1 = getMockAnswerConcept();
+        ConceptMap conceptMap = new ConceptMap(conceptReferenceTerm, conceptMapType);
+        concept1.addConceptMapping(conceptMap);
+        conceptList.add(concept1);
+        return conceptList;
+    }
+
+    private ConceptMapType getMockConceptMapType(String name) {
+        ConceptMapType conceptMapType = new ConceptMapType();
+        conceptMapType.setName(name);
+        return conceptMapType;
     }
 }

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/BahmniObservationAnswerConceptSaveCommandTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/BahmniObservationAnswerConceptSaveCommandTest.java
@@ -239,7 +239,7 @@ public class BahmniObservationAnswerConceptSaveCommandTest {
     private List<BahmniObservation> createBahmniObservation(String conceptSystem, boolean isCodedAnswerFromTermimologyServer) {
         String codedAnswerUuid = null;
         if (isCodedAnswerFromTermimologyServer) {
-            codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "61462000";
+            codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "dummyConceptCode";
         } else {
             codedAnswerUuid = "coded-answer-uuid";
         }
@@ -308,7 +308,7 @@ public class BahmniObservationAnswerConceptSaveCommandTest {
         } else {
             mockConceptMapType = "narrowerThan";
         }
-        String mockReferenceTermCode = "61462000";
+        String mockReferenceTermCode = "dummyConceptCode";
         ConceptSource conceptSource = getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE);
 
         String mockConceptName = "dummyConcept";

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolverTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolverTest.java
@@ -69,11 +69,11 @@ public class TSConceptUuidResolverTest {
     @InjectMocks
     TSConceptUuidResolver tsConceptUuidResolver;
     @Mock
+    EmrApiProperties emrApiProperties;
+    @Mock
     private FhirConceptSourceService conceptSourceService;
     @Mock
     private UserContext userContext;
-    @Mock
-    EmrApiProperties emrApiProperties;
 
     @Before
     public void setUp() {
@@ -199,6 +199,7 @@ public class TSConceptUuidResolverTest {
         verify(conceptService, times(0)).saveConcept(any(Concept.class));
         assertEquals("coded-answer-uuid", concept.getUuid());
     }
+
     @Test
     public void shouldThrowExceptionWhenConceptNotFoundForGivenConceptId() {
         String mockConceptUuid = "mock-uuid";
@@ -208,6 +209,7 @@ public class TSConceptUuidResolverTest {
         tsConceptUuidResolver.getConceptSetByUuid(mockConceptUuid);
 
     }
+
     @Test
     public void shouldThrowExceptionWhenDefaultDiagnosisConceptSetNotFound() {
         when(emrApiProperties.getDiagnosisSets()).thenReturn(new ArrayList<>());
@@ -218,15 +220,16 @@ public class TSConceptUuidResolverTest {
     }
 
     @Test
-    public  void shouldReturnConceptWithSameAsMapTypeWhenSearchedByReferenceTermCodeAndConceptSourceAndConceptListContainsWithSameAsMapType() {
+    public void shouldReturnConceptWithSameAsMapTypeWhenSearchedByReferenceTermCodeAndConceptSourceAndConceptListContainsWithSameAsMapType() {
         List<Concept> mockConcetplist = getMockConceptList(true);
         when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConcetplist);
         when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
         Concept concept = tsConceptUuidResolver.getConceptByReferenceTermCodeAndConceptSource("mockReferenceTermCode", MOCK_CONCEPT_SYSTEM);
         assertNotNull(concept);
     }
+
     @Test
-    public  void shouldReturnNullWhenSearchedByReferenceTermCodeAndConceptSourceAndConceptListContainsWithoutSameAsMapType() {
+    public void shouldReturnNullWhenSearchedByReferenceTermCodeAndConceptSourceAndConceptListContainsWithoutSameAsMapType() {
         List<Concept> mockConcetplist = getMockConceptList(false);
         when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConcetplist);
         when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
@@ -293,9 +296,10 @@ public class TSConceptUuidResolverTest {
         concept.setSet(true);
         return concept;
     }
+
     private List<Concept> getMockConceptList(boolean isSameAs) {
         String mockConceptMapType = "";
-        if(isSameAs) {
+        if (isSameAs) {
             mockConceptMapType = "sameAs";
         } else {
             mockConceptMapType = "narrowerThan";
@@ -304,7 +308,7 @@ public class TSConceptUuidResolverTest {
         ConceptSource conceptSource = getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE);
 
         String mockConceptName = "dummyConcept";
-        ConceptReferenceTerm conceptReferenceTerm  = new ConceptReferenceTerm(conceptSource, mockReferenceTermCode, mockConceptName);
+        ConceptReferenceTerm conceptReferenceTerm = new ConceptReferenceTerm(conceptSource, mockReferenceTermCode, mockConceptName);
         ConceptMapType conceptMapType = getMockConceptMapType(mockConceptMapType);
         List<Concept> conceptList = new ArrayList<>();
         Concept concept1 = getDiagnosisConcept();
@@ -313,6 +317,7 @@ public class TSConceptUuidResolverTest {
         conceptList.add(concept1);
         return conceptList;
     }
+
     private ConceptMapType getMockConceptMapType(String name) {
         ConceptMapType conceptMapType = new ConceptMapType();
         conceptMapType.setName(name);

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolverTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolverTest.java
@@ -224,20 +224,20 @@ public class TSConceptUuidResolverTest {
     }
 
     @Test
-    public void shouldReturnConceptWithSameAsMapTypeWhenSearchedByReferenceTermCodeAndConceptSourceAndConceptListContainsWithSameAsMapType() {
+    public void shouldReturnConceptWithSameAsMapTypeWhenConceptListContainsSameAsMapTypeAndReferenceTermCodeAndConceptSourceIsPassed() {
         List<Concept> mockConcetplist = getMockConceptList(true);
         when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConcetplist);
         when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
-        Concept concept = tsConceptUuidResolver.getConceptByReferenceTermCodeAndConceptSource("61462000", MOCK_CONCEPT_SYSTEM);
+        Concept concept = tsConceptUuidResolver.getConceptByReferenceTermCodeAndConceptSource("dummyConceptCode", MOCK_CONCEPT_SYSTEM);
         assertNotNull(concept);
     }
 
     @Test
-    public void shouldReturnNullWhenSearchedByReferenceTermCodeAndConceptSourceAndConceptListContainsWithoutSameAsMapType() {
+    public void shouldReturnNullWhenConceptListDoesNotContainSameAsMapTypeAndReferenceTermCodeAndConceptSourceIsPassed() {
         List<Concept> mockConcetplist = getMockConceptList(false);
         when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConcetplist);
         when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
-        Concept concept = tsConceptUuidResolver.getConceptByReferenceTermCodeAndConceptSource("61462000", MOCK_CONCEPT_SYSTEM);
+        Concept concept = tsConceptUuidResolver.getConceptByReferenceTermCodeAndConceptSource("dummyConceptCode", MOCK_CONCEPT_SYSTEM);
         assertNull(concept);
     }
 
@@ -249,7 +249,7 @@ public class TSConceptUuidResolverTest {
     private EncounterTransaction.Concept createBahmniEncounterTransactionConcept(String conceptSystem, boolean isCodedAnswerFromTerminologyServer) {
         String codedAnswerUuid = null;
         if (isCodedAnswerFromTerminologyServer)
-            codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "61462000";
+            codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "dummyConceptCode";
         else
             codedAnswerUuid = "coded-answer-uuid";
         return new EncounterTransaction.Concept(codedAnswerUuid);
@@ -266,7 +266,7 @@ public class TSConceptUuidResolverTest {
         String codedAnswerUuid = null;
         String conceptName = "dummy-concept";
         if (isCodedAnswerFromTerminologyServer)
-            codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "61462000";
+            codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "dummyConceptCode";
         else
             codedAnswerUuid = "coded-answer-uuid";
         return new org.openmrs.module.emrapi.conditionslist.contract.Concept(codedAnswerUuid, conceptName);
@@ -308,7 +308,7 @@ public class TSConceptUuidResolverTest {
         } else {
             mockConceptMapType = "narrowerThan";
         }
-        String mockReferenceTermCode = "61462000";
+        String mockReferenceTermCode = "dummyConceptCode";
         ConceptSource conceptSource = getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE);
 
         String mockConceptName = "dummyConcept";

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolverTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolverTest.java
@@ -108,7 +108,9 @@ public class TSConceptUuidResolverTest {
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
         org.openmrs.module.emrapi.conditionslist.contract.Concept concept = getBahmniConditionConcept(MOCK_CONCEPT_SYSTEM, true);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
-        when(conceptService.getConceptByMapping(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
+        List<Concept> mockConceptList = getMockConceptList(true);
+        when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConceptList);
+        when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
         when(conceptService.getConceptByUuid(UNCLASSIFIED_CONCEPT_SET_UUID)).thenReturn(unclassifiedConceptSet);
         when(terminologyLookupService.getConcept(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
@@ -166,7 +168,9 @@ public class TSConceptUuidResolverTest {
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
         EncounterTransaction.Concept concept = getBahmniEncounterTransactionConcept(MOCK_CONCEPT_SYSTEM, true);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
-        when(conceptService.getConceptByMapping(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
+        List<Concept> mockConceptList = getMockConceptList(true);
+        when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConceptList);
+        when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
         when(conceptService.getConceptByUuid(UNCLASSIFIED_CONCEPT_SET_UUID)).thenReturn(unclassifiedConceptSet);
         when(terminologyLookupService.getConcept(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
@@ -224,7 +228,7 @@ public class TSConceptUuidResolverTest {
         List<Concept> mockConcetplist = getMockConceptList(true);
         when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConcetplist);
         when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
-        Concept concept = tsConceptUuidResolver.getConceptByReferenceTermCodeAndConceptSource("mockReferenceTermCode", MOCK_CONCEPT_SYSTEM);
+        Concept concept = tsConceptUuidResolver.getConceptByReferenceTermCodeAndConceptSource("61462000", MOCK_CONCEPT_SYSTEM);
         assertNotNull(concept);
     }
 
@@ -233,7 +237,7 @@ public class TSConceptUuidResolverTest {
         List<Concept> mockConcetplist = getMockConceptList(false);
         when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConcetplist);
         when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
-        Concept concept = tsConceptUuidResolver.getConceptByReferenceTermCodeAndConceptSource("mockReferenceTermCode", MOCK_CONCEPT_SYSTEM);
+        Concept concept = tsConceptUuidResolver.getConceptByReferenceTermCodeAndConceptSource("61462000", MOCK_CONCEPT_SYSTEM);
         assertNull(concept);
     }
 
@@ -304,7 +308,7 @@ public class TSConceptUuidResolverTest {
         } else {
             mockConceptMapType = "narrowerThan";
         }
-        String mockReferenceTermCode = "mockReferenceTermCode";
+        String mockReferenceTermCode = "61462000";
         ConceptSource conceptSource = getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE);
 
         String mockConceptName = "dummyConcept";

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/ConditionConceptSaveImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/ConditionConceptSaveImplTest.java
@@ -183,7 +183,7 @@ public class ConditionConceptSaveImplTest {
         String codedAnswerUuid = null;
         String conceptName = "dummy-concept";
         if (isCodedAnswerFromTermimologyServer)
-            codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "61462000";
+            codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "dummyConceptCode";
         else
             codedAnswerUuid = "coded-answer-uuid";
         org.openmrs.module.emrapi.conditionslist.contract.Condition condition = new org.openmrs.module.emrapi.conditionslist.contract.Condition();
@@ -227,7 +227,7 @@ public class ConditionConceptSaveImplTest {
         } else {
             mockConceptMapType = "narrowerThan";
         }
-        String mockReferenceTermCode = "61462000";
+        String mockReferenceTermCode = "dummyConceptCode";
         ConceptSource conceptSource = getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE);
 
         String mockConceptName = "dummyConcept";

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/ConditionConceptSaveImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/ConditionConceptSaveImplTest.java
@@ -9,7 +9,10 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.openmrs.Concept;
+import org.openmrs.ConceptMap;
+import org.openmrs.ConceptMapType;
 import org.openmrs.ConceptName;
+import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.ConceptSource;
 import org.openmrs.api.APIException;
 import org.openmrs.api.AdministrationService;
@@ -25,6 +28,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -111,7 +116,9 @@ public class ConditionConceptSaveImplTest {
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
         org.openmrs.module.emrapi.conditionslist.contract.Condition condition = getBahmniCondition(MOCK_CONCEPT_SYSTEM, true);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
-        when(conceptService.getConceptByMapping(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
+        List<Concept> mockConceptList = getMockConceptList(true);
+        when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConceptList);
+        when(conceptService.getConceptMapTypeByUuid(anyString())).thenReturn(getMockConceptMapType("sameAs"));
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
         when(conceptService.getConceptByUuid(UNCLASSIFIED_CONCEPT_SET_UUID)).thenReturn(unclassifiedConceptSet);
         when(terminologyLookupService.getConcept(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
@@ -211,6 +218,33 @@ public class ConditionConceptSaveImplTest {
         concept.setFullySpecifiedName(fullySpecifiedName);
         concept.setSet(true);
         return concept;
+    }
+
+    private List<Concept> getMockConceptList(boolean isSameAs) {
+        String mockConceptMapType = "";
+        if (isSameAs) {
+            mockConceptMapType = "sameAs";
+        } else {
+            mockConceptMapType = "narrowerThan";
+        }
+        String mockReferenceTermCode = "61462000";
+        ConceptSource conceptSource = getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE);
+
+        String mockConceptName = "dummyConcept";
+        ConceptReferenceTerm conceptReferenceTerm = new ConceptReferenceTerm(conceptSource, mockReferenceTermCode, mockConceptName);
+        ConceptMapType conceptMapType = getMockConceptMapType(mockConceptMapType);
+        List<Concept> conceptList = new ArrayList<>();
+        Concept concept1 = getDiagnosisConcept();
+        ConceptMap conceptMap = new ConceptMap(conceptReferenceTerm, conceptMapType);
+        concept1.addConceptMapping(conceptMap);
+        conceptList.add(concept1);
+        return conceptList;
+    }
+
+    private ConceptMapType getMockConceptMapType(String name) {
+        ConceptMapType conceptMapType = new ConceptMapType();
+        conceptMapType.setName(name);
+        return conceptMapType;
     }
 
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary
Fix for multiple concepts having same concept source and reference term code with different map types. this happens with the preloaded Ciel dictionary with clinic config

## Screenshots
<!-- Required if you are making UI changes. -->

## JIRA tickets
https://bahmni.atlassian.net/browse/BS-127
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://bahmni.atlassian.net/jira/software/c/projects/BAH/boards/28?selectedIssue=BAH-1394- -->

## Other
<!-- Anything not covered above -->