### PR TITLE
BS-178 | Added a request timeout for the IRestfulClientFactory

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -1,7 +1,7 @@
 name: Build and Publish package
 on:
   push:
-    branches: [ main ]
+    branches: [ main, BS-178 ]
   workflow_dispatch:
 
 jobs:

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
@@ -17,6 +17,7 @@ import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RestUtil;
 import org.springframework.http.HttpStatus;
+import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -150,7 +151,9 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
     }
 
     private ValueSet fetchValueSet(String valueSetEndPoint) {
-        return fhirContext.newRestfulGenericClient(getTSBaseUrl()).read().resource(ValueSet.class).withUrl(valueSetEndPoint).execute();
+        IRestfulClientFactory iRestfulClientFactory = fhirContext.getRestfulClientFactory();
+        iRestfulClientFactory.setSocketTimeout(30*60*1000);
+        return iRestfulClientFactory.newGenericClient(getTSBaseUrl()).read().resource(ValueSet.class).withUrl(valueSetEndPoint).execute();
     }
 
     private Integer getRecordLimit(Integer limit) {

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
@@ -152,7 +152,9 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
 
     private ValueSet fetchValueSet(String valueSetEndPoint) {
         IRestfulClientFactory iRestfulClientFactory = fhirContext.getRestfulClientFactory();
-        iRestfulClientFactory.setSocketTimeout(30*60*1000);
+        iRestfulClientFactory.setSocketTimeout(5*60*1000);
+        iRestfulClientFactory.setConnectTimeout(1*60*1000);
+        iRestfulClientFactory.setConnectionRequestTimeout(5*60*1000);
         return iRestfulClientFactory.newGenericClient(getTSBaseUrl()).read().resource(ValueSet.class).withUrl(valueSetEndPoint).execute();
     }
 

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
@@ -100,7 +100,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
@@ -155,7 +154,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new FhirClientConnectionException("Invalid Connection"));
@@ -169,7 +167,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new UnclassifiedServerFailureException(502, "HTTP 502 Bad Gateway"));
@@ -183,7 +180,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new ResourceNotFoundException("Not Found"));
@@ -198,7 +194,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY/sct?fhir_vs=ecl/<<");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("ValueSet/$expand?url={0}{1}&displayLanguage={2}&count={3,number,#}&offset={4,number,#}");
         ValueSet valueSet = getMockValueSet();
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
@@ -216,7 +211,6 @@ public class TerminologyLookupServiceImplTest {
         ValueSet valueSet = getMockValueSetForConcept();
         Concept mockConcept = getMockConcept();
 
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
@@ -236,7 +230,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.OBSERVATION_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
@@ -3,6 +3,7 @@ package org.bahmni.module.fhirterminologyservices.api.impl;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
 import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.UnclassifiedServerFailureException;
@@ -52,6 +53,9 @@ public class TerminologyLookupServiceImplTest {
     private FhirContext fhirContext;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private IGenericClient iGenericClient;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private IRestfulClientFactory iRestfulClientFactory;
     @Mock
     private ValueSetMapper<List<SimpleObject>> vsSimpleObjectMapper;
     @Mock
@@ -96,7 +100,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(vsSimpleObjectMapper.map(any(ValueSet.class))).thenReturn(simpleObjectSingletonList);
         List<SimpleObject> diagnosisSearchList = terminologyLookupService.searchConcepts("Asthma", 1, null);
@@ -149,7 +155,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new FhirClientConnectionException("Invalid Connection"));
         assertThrows(TerminologyServicesException.class, () ->
                 terminologyLookupService.searchConcepts("Malaria", 10, null)
@@ -161,7 +169,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new UnclassifiedServerFailureException(502, "HTTP 502 Bad Gateway"));
         assertThrows(TerminologyServicesException.class, () ->
                 terminologyLookupService.searchConcepts("Malaria", 10, null)
@@ -173,7 +183,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new ResourceNotFoundException("Not Found"));
         assertThrows(TerminologyServicesException.class, () ->
                 terminologyLookupService.searchConcepts("Malaria", 10, null)
@@ -186,7 +198,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY/sct?fhir_vs=ecl/<<");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("ValueSet/$expand?url={0}{1}&displayLanguage={2}&count={3,number,#}&offset={4,number,#}");
         ValueSet valueSet = getMockValueSet();
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         ValueSet valueSetResponse = terminologyLookupService.searchTerminologyCodes("12345", 10, 0, "en");
         assertEquals(valueSet,valueSetResponse);
@@ -202,7 +216,9 @@ public class TerminologyLookupServiceImplTest {
         ValueSet valueSet = getMockValueSetForConcept();
         Concept mockConcept = getMockConcept();
 
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(vsConceptMapper.map(any(ValueSet.class))).thenReturn(mockConcept);
 
@@ -220,7 +236,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.OBSERVATION_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(vsSimpleObjectMapper.map(any(ValueSet.class))).thenReturn(simpleObjectSingletonList);
         List<SimpleObject> diagnosisSearchList = terminologyLookupService.searchConcepts("http://DUMMY_VALUESET_URL", null, null, null);


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary
Extended the default request timeout for the IRestfulClient to cater to SNOMED reports that exhibit extended response times, particularly the clinical finding diagnosis (ICD) report.

## Screenshots
![clinicalFindings](https://github.com/Bahmni/openmrs-module-snomed/assets/16693480/2b3d0855-22d5-4f5e-ada8-53f366e940ef)


## JIRA tickets
https://bahmni.atlassian.net/browse/BS-178
