### PR TITLE
BS-178 | Increased request timeout for the IRestfulClientFactory 

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -1,7 +1,7 @@
 name: Build and Publish package
 on:
   push:
-    branches: [ main, BS-178 ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -1,7 +1,7 @@
 name: Build and Publish package
 on:
   push:
-    branches: [ main ]
+    branches: [ main, BS-178 ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -1,7 +1,7 @@
 name: Build and Publish package
 on:
   push:
-    branches: [ main , BS-178 ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -1,7 +1,7 @@
 name: Build and Publish package
 on:
   push:
-    branches: [ main ]
+    branches: [ main , BS-178 ]
   workflow_dispatch:
 
 jobs:

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TerminologyLookupService.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TerminologyLookupService.java
@@ -20,6 +20,9 @@ public interface TerminologyLookupService extends OpenmrsService {
     public static final String CONCEPT_DETAILS_URL_GLOBAL_PROP = "ts.fhir.conceptDetailsUrl";
     public static final String PROCEDURE_VALUESET_URL_GLOBAL_PROP = "ts.fhir.procedure.valueset.urltemplate";
     public static final String OBSERVATION_FORMAT = "json";
+    public static final String SOCKET_TIME_OUT = "ts.socket.timeout";
+    public static final String CONNECTION_TIME_OUT = "ts.connection.timeout";
+    public static final String CONNECTION_REQUEST_TIME_OUT = "ts.connection.request.timeout";
 
     @Authorized(value = {"Get Concepts"})
     List<SimpleObject> searchConcepts(String searchTerm, Integer limit, String locale);

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TerminologyLookupService.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TerminologyLookupService.java
@@ -20,9 +20,9 @@ public interface TerminologyLookupService extends OpenmrsService {
     public static final String CONCEPT_DETAILS_URL_GLOBAL_PROP = "ts.fhir.conceptDetailsUrl";
     public static final String PROCEDURE_VALUESET_URL_GLOBAL_PROP = "ts.fhir.procedure.valueset.urltemplate";
     public static final String OBSERVATION_FORMAT = "json";
-    public static final String SOCKET_TIME_OUT = "ts.socket.timeout";
-    public static final String CONNECTION_TIME_OUT = "ts.connection.timeout";
-    public static final String CONNECTION_REQUEST_TIME_OUT = "ts.connection.request.timeout";
+    public static final String SOCKET_TIMEOUT_GLOBAL_PROP = "ts.fhir.valueset.socket.timeout";
+    public static final String CONNECTION_TIMEOUT_GLOBAL_PROP = "ts.fhir.valueset.connection.timeout";
+    public static final String CONNECTION_REQUEST_TIMEOUT_GLOBAL_PROP = "ts.fhir.valueset.connection.request.timeout";
 
     @Authorized(value = {"Get Concepts"})
     List<SimpleObject> searchConcepts(String searchTerm, Integer limit, String locale);

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
@@ -31,6 +31,12 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
     private FhirContext fhirContext = FhirContext.forR4();
     private ValueSetMapper<List<SimpleObject>> vsSimpleObjectMapper;
     private ValueSetMapper<Concept> vsConceptMapper;
+    public static final int SOCKET_TIME_OUT_FIVE_MINUTES = 5*60*1000;
+    public static final int CONNECTION_TIME_OUT_ONE_MINUTE = 1*60*1000;
+    public static final int CONNECTION_REQUEST_TIME_OUT_FIVE_MINUTES = 5*60*1000;
+
+//    int connectTimeout;
+//    int connectRequestTimeOut;
 
     public TerminologyLookupServiceImpl(ValueSetMapper<List<SimpleObject>> vsSimpleObjectMapper, ValueSetMapper<Concept> vsConceptMapper) {
         this.vsSimpleObjectMapper = vsSimpleObjectMapper;
@@ -152,9 +158,9 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
 
     private ValueSet fetchValueSet(String valueSetEndPoint) {
         IRestfulClientFactory iRestfulClientFactory = fhirContext.getRestfulClientFactory();
-        iRestfulClientFactory.setSocketTimeout(5*60*1000);
-        iRestfulClientFactory.setConnectTimeout(1*60*1000);
-        iRestfulClientFactory.setConnectionRequestTimeout(5*60*1000);
+        iRestfulClientFactory.setSocketTimeout(getTsSocketTimeOut());
+        iRestfulClientFactory.setConnectTimeout(getTsConnectionTimeOut(connectTimeout));
+        iRestfulClientFactory.setConnectionRequestTimeout(getTsConnectRequestTimeOut(connectRequestTimeOut));
         return iRestfulClientFactory.newGenericClient(getTSBaseUrl()).read().resource(ValueSet.class).withUrl(valueSetEndPoint).execute();
     }
 
@@ -164,6 +170,18 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
 
     private String getLocaleLanguage(String lang) {
         return StringUtils.isNotBlank(lang) ? lang : Context.getLocale().getLanguage();
+    }
+    private Integer getTsSocketTimeOut(){
+        int socketTimeOut = Context.getAdministrationService().getGlobalProperty((TerminologyLookupService.SOCKET_TIME_OUT));
+        return (socketTimeOut ==0 ) ? socketTimeOut : SOCKET_TIME_OUT_FIVE_MINUTES ;
+    }
+    private Integer getTsConnectionTimeOut(){
+        int connectTimeout = Integer.valueOf(Context.getAdministrationService().getGlobalProperty((TerminologyLookupService.CONNECTION_TIME_OUT)));
+        return (connectTimeout ==0 ) ? connectTimeout : CONNECTION_TIME_OUT_ONE_MINUTE ;
+    }
+    private Integer getTsConnectRequestTimeOut(){
+        int connectRequestTimeOut = Integer.valueOf(Context.getAdministrationService().getGlobalProperty((TerminologyLookupService.CONNECTION_REQUEST_TIME_OUT)));
+        return (connectRequestTimeOut ==0 ) ? connectRequestTimeOut : CONNECTION_REQUEST_TIME_OUT_FIVE_MINUTES ;
     }
 
     private void handleException(Exception exception) {

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
@@ -1,6 +1,7 @@
 package org.bahmni.module.fhirterminologyservices.api.impl;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
 import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.UnclassifiedServerFailureException;
@@ -17,7 +18,6 @@ import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RestUtil;
 import org.springframework.http.HttpStatus;
-import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -31,12 +31,9 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
     private FhirContext fhirContext = FhirContext.forR4();
     private ValueSetMapper<List<SimpleObject>> vsSimpleObjectMapper;
     private ValueSetMapper<Concept> vsConceptMapper;
-    public static final int SOCKET_TIME_OUT_FIVE_MINUTES = 5*60*1000;
-    public static final int CONNECTION_TIME_OUT_ONE_MINUTE = 1*60*1000;
-    public static final int CONNECTION_REQUEST_TIME_OUT_FIVE_MINUTES = 5*60*1000;
-
-//    int connectTimeout;
-//    int connectRequestTimeOut;
+    public static final int SOCKET_TIME_OUT_FIVE_MINUTES = 5 * 60 * 1000;
+    public static final int CONNECTION_TIME_OUT_ONE_MINUTE = 1 * 60 * 1000;
+    public static final int CONNECTION_REQUEST_TIME_OUT_FIVE_MINUTES = 5 * 60 * 1000;
 
     public TerminologyLookupServiceImpl(ValueSetMapper<List<SimpleObject>> vsSimpleObjectMapper, ValueSetMapper<Concept> vsConceptMapper) {
         this.vsSimpleObjectMapper = vsSimpleObjectMapper;
@@ -61,7 +58,7 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
     @Override
     public List<SimpleObject> searchConcepts(String valueSetUrl, String lang, String searchTerm, Integer limit) {
         if (searchTerm == null) {
-          searchTerm = "";
+            searchTerm = "";
         }
         ValueSet valueSet = null;
         try {
@@ -103,7 +100,7 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
     }
 
     @Override
-    public ValueSet searchTerminologyCodes(String snomedCode, Integer pageSize, Integer offset, String locale){
+    public ValueSet searchTerminologyCodes(String snomedCode, Integer pageSize, Integer offset, String locale) {
         String baseUrl = getTSBaseUrl();
         String valueSetUrl = getTSGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_GLOBAL_PROP);
         String valueSetUrlTemplate = getTSGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP);
@@ -124,6 +121,7 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
         String relativeUrl = MessageFormat.format(valueSetUrlTemplate, encode(valueSetUrl), encode(searchTerm), recordLimit, localeLanguage, includeDesignations);
         return baseUrl + relativeUrl;
     }
+
     private String getValueSetEndPoint(String valueSetUrlTemplate, String valueSetUrl, String localeLanguage, String format, String searchTerm, Integer limit) throws UnsupportedEncodingException, TerminologyServicesException {
         String baseUrl = getTSBaseUrl();
         String relativeUrl = MessageFormat.format(valueSetUrlTemplate, encode(valueSetUrl), localeLanguage, format, encode(searchTerm), limit);
@@ -141,6 +139,7 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
     private String getDiagnosisSearchVSUrl() throws TerminologyServicesException {
         return getTSGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP);
     }
+
     private String getObservationSearchVSUrl() throws TerminologyServicesException {
         return getTSGlobalProperty(TerminologyLookupService.OBSERVATION_VALUE_SET_URL_GLOBAL_PROP);
     }
@@ -158,9 +157,9 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
 
     private ValueSet fetchValueSet(String valueSetEndPoint) {
         IRestfulClientFactory iRestfulClientFactory = fhirContext.getRestfulClientFactory();
-        iRestfulClientFactory.setSocketTimeout(getTsSocketTimeOut());
-        iRestfulClientFactory.setConnectTimeout(getTsConnectionTimeOut(connectTimeout));
-        iRestfulClientFactory.setConnectionRequestTimeout(getTsConnectRequestTimeOut(connectRequestTimeOut));
+        iRestfulClientFactory.setSocketTimeout(getSocketTimeOut());
+        iRestfulClientFactory.setConnectTimeout(getConnectionTimeOut());
+        iRestfulClientFactory.setConnectionRequestTimeout(getConnectionRequestTimeOut());
         return iRestfulClientFactory.newGenericClient(getTSBaseUrl()).read().resource(ValueSet.class).withUrl(valueSetEndPoint).execute();
     }
 
@@ -171,17 +170,20 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
     private String getLocaleLanguage(String lang) {
         return StringUtils.isNotBlank(lang) ? lang : Context.getLocale().getLanguage();
     }
-    private Integer getTsSocketTimeOut(){
-        int socketTimeOut = Context.getAdministrationService().getGlobalProperty((TerminologyLookupService.SOCKET_TIME_OUT));
-        return (socketTimeOut ==0 ) ? socketTimeOut : SOCKET_TIME_OUT_FIVE_MINUTES ;
+
+    private Integer getSocketTimeOut() {
+        String socketTimeOutStr = Context.getAdministrationService().getGlobalProperty((TerminologyLookupService.SOCKET_TIMEOUT_GLOBAL_PROP));
+        return StringUtils.isNumeric(socketTimeOutStr) ? Integer.valueOf(socketTimeOutStr) : SOCKET_TIME_OUT_FIVE_MINUTES;
     }
-    private Integer getTsConnectionTimeOut(){
-        int connectTimeout = Integer.valueOf(Context.getAdministrationService().getGlobalProperty((TerminologyLookupService.CONNECTION_TIME_OUT)));
-        return (connectTimeout ==0 ) ? connectTimeout : CONNECTION_TIME_OUT_ONE_MINUTE ;
+
+    private Integer getConnectionTimeOut() {
+        String connectTimeoutStr = Context.getAdministrationService().getGlobalProperty((TerminologyLookupService.CONNECTION_TIMEOUT_GLOBAL_PROP));
+        return StringUtils.isNumeric(connectTimeoutStr) ? Integer.valueOf(connectTimeoutStr) : CONNECTION_TIME_OUT_ONE_MINUTE;
     }
-    private Integer getTsConnectRequestTimeOut(){
-        int connectRequestTimeOut = Integer.valueOf(Context.getAdministrationService().getGlobalProperty((TerminologyLookupService.CONNECTION_REQUEST_TIME_OUT)));
-        return (connectRequestTimeOut ==0 ) ? connectRequestTimeOut : CONNECTION_REQUEST_TIME_OUT_FIVE_MINUTES ;
+
+    private Integer getConnectionRequestTimeOut() {
+        String connectionRequestTimeOutStr = Context.getAdministrationService().getGlobalProperty((TerminologyLookupService.CONNECTION_REQUEST_TIMEOUT_GLOBAL_PROP));
+        return StringUtils.isNumeric(connectionRequestTimeOutStr) ? Integer.valueOf(connectionRequestTimeOutStr) : CONNECTION_REQUEST_TIME_OUT_FIVE_MINUTES;
     }
 
     private void handleException(Exception exception) {

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
@@ -17,6 +17,7 @@ import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RestUtil;
 import org.springframework.http.HttpStatus;
+import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -150,7 +151,9 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
     }
 
     private ValueSet fetchValueSet(String valueSetEndPoint) {
-        return fhirContext.newRestfulGenericClient(getTSBaseUrl()).read().resource(ValueSet.class).withUrl(valueSetEndPoint).execute();
+        IRestfulClientFactory iRestfulClientFactory = fhirContext.getRestfulClientFactory();
+        iRestfulClientFactory.setSocketTimeout(30*60*1000);
+        return iRestfulClientFactory.newGenericClient(getTSBaseUrl()).read().resource(ValueSet.class).withUrl(valueSetEndPoint).execute();
     }
 
     private Integer getRecordLimit(Integer limit) {

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
@@ -152,7 +152,9 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
 
     private ValueSet fetchValueSet(String valueSetEndPoint) {
         IRestfulClientFactory iRestfulClientFactory = fhirContext.getRestfulClientFactory();
-        iRestfulClientFactory.setSocketTimeout(30*60*1000);
+        iRestfulClientFactory.setSocketTimeout(5*60*1000);
+        iRestfulClientFactory.setConnectTimeout(1*60*1000);
+        iRestfulClientFactory.setConnectionRequestTimeout(5*60*1000);
         return iRestfulClientFactory.newGenericClient(getTSBaseUrl()).read().resource(ValueSet.class).withUrl(valueSetEndPoint).execute();
     }
 

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
@@ -100,7 +100,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
@@ -155,7 +154,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new FhirClientConnectionException("Invalid Connection"));
@@ -169,7 +167,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new UnclassifiedServerFailureException(502, "HTTP 502 Bad Gateway"));
@@ -183,7 +180,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new ResourceNotFoundException("Not Found"));
@@ -198,7 +194,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY/sct?fhir_vs=ecl/<<");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("ValueSet/$expand?url={0}{1}&displayLanguage={2}&count={3,number,#}&offset={4,number,#}");
         ValueSet valueSet = getMockValueSet();
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
@@ -216,7 +211,6 @@ public class TerminologyLookupServiceImplTest {
         ValueSet valueSet = getMockValueSetForConcept();
         Concept mockConcept = getMockConcept();
 
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
@@ -236,7 +230,6 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.OBSERVATION_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
-        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
@@ -2,7 +2,6 @@ package org.bahmni.module.fhirterminologyservices.api.impl;
 
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
 import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
@@ -52,9 +51,6 @@ public class TerminologyLookupServiceImplTest {
     @Mock
     private FhirContext fhirContext;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private IGenericClient iGenericClient;
-
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private IRestfulClientFactory iRestfulClientFactory;
     @Mock
     private ValueSetMapper<List<SimpleObject>> vsSimpleObjectMapper;
@@ -101,8 +97,7 @@ public class TerminologyLookupServiceImplTest {
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
-        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
-        when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
+        when(iRestfulClientFactory.newGenericClient(anyString()).read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(vsSimpleObjectMapper.map(any(ValueSet.class))).thenReturn(simpleObjectSingletonList);
         List<SimpleObject> diagnosisSearchList = terminologyLookupService.searchConcepts("Asthma", 1, null);
         assertNotNull(diagnosisSearchList);
@@ -155,8 +150,7 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
-        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
-        when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new FhirClientConnectionException("Invalid Connection"));
+        when(iRestfulClientFactory.newGenericClient(anyString()).read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new FhirClientConnectionException("Invalid Connection"));
         assertThrows(TerminologyServicesException.class, () ->
                 terminologyLookupService.searchConcepts("Malaria", 10, null)
         );
@@ -168,8 +162,7 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
-        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
-        when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new UnclassifiedServerFailureException(502, "HTTP 502 Bad Gateway"));
+        when(iRestfulClientFactory.newGenericClient(anyString()).read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new UnclassifiedServerFailureException(502, "HTTP 502 Bad Gateway"));
         assertThrows(TerminologyServicesException.class, () ->
                 terminologyLookupService.searchConcepts("Malaria", 10, null)
         );
@@ -181,24 +174,22 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
-        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
-        when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new ResourceNotFoundException("Not Found"));
+        when(iRestfulClientFactory.newGenericClient(anyString()).read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new ResourceNotFoundException("Not Found"));
         assertThrows(TerminologyServicesException.class, () ->
                 terminologyLookupService.searchConcepts("Malaria", 10, null)
         );
     }
 
     @Test
-    public void shouldGetValueSetWithDescendantCodes_whenValidTerminologyCodeIsProvided(){
+    public void shouldGetValueSetWithDescendantCodes_whenValidTerminologyCodeIsProvided() {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY/sct?fhir_vs=ecl/<<");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("ValueSet/$expand?url={0}{1}&displayLanguage={2}&count={3,number,#}&offset={4,number,#}");
         ValueSet valueSet = getMockValueSet();
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
-        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
-        when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
+        when(iRestfulClientFactory.newGenericClient(anyString()).read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         ValueSet valueSetResponse = terminologyLookupService.searchTerminologyCodes("12345", 10, 0, "en");
-        assertEquals(valueSet,valueSetResponse);
+        assertEquals(valueSet, valueSetResponse);
     }
 
     @Test
@@ -212,8 +203,7 @@ public class TerminologyLookupServiceImplTest {
         Concept mockConcept = getMockConcept();
 
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
-        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
-        when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
+        when(iRestfulClientFactory.newGenericClient(anyString()).read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(vsConceptMapper.map(any(ValueSet.class))).thenReturn(mockConcept);
 
 
@@ -230,10 +220,7 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.OBSERVATION_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
-//        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
-//        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
-       // when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(iRestfulClientFactory.newGenericClient(anyString()).read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(vsSimpleObjectMapper.map(any(ValueSet.class))).thenReturn(simpleObjectSingletonList);
         List<SimpleObject> diagnosisSearchList = terminologyLookupService.searchConcepts("http://DUMMY_VALUESET_URL", null, null, null);

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
@@ -3,6 +3,7 @@ package org.bahmni.module.fhirterminologyservices.api.impl;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
 import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.UnclassifiedServerFailureException;
@@ -52,6 +53,9 @@ public class TerminologyLookupServiceImplTest {
     private FhirContext fhirContext;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private IGenericClient iGenericClient;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private IRestfulClientFactory iRestfulClientFactory;
     @Mock
     private ValueSetMapper<List<SimpleObject>> vsSimpleObjectMapper;
     @Mock
@@ -96,7 +100,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(vsSimpleObjectMapper.map(any(ValueSet.class))).thenReturn(simpleObjectSingletonList);
         List<SimpleObject> diagnosisSearchList = terminologyLookupService.searchConcepts("Asthma", 1, null);
@@ -149,7 +155,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new FhirClientConnectionException("Invalid Connection"));
         assertThrows(TerminologyServicesException.class, () ->
                 terminologyLookupService.searchConcepts("Malaria", 10, null)
@@ -161,7 +169,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new UnclassifiedServerFailureException(502, "HTTP 502 Bad Gateway"));
         assertThrows(TerminologyServicesException.class, () ->
                 terminologyLookupService.searchConcepts("Malaria", 10, null)
@@ -173,7 +183,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.TERMINOLOGY_SERVER_BASE_URL_GLOBAL_PROP)).thenReturn("https://DUMMY_TS_URL/");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_SEARCH_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         when(administrationService.getGlobalProperty(TerminologyLookupService.FHIR_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("DUMMY_VALUESET_TEMPLATE");
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenThrow(new ResourceNotFoundException("Not Found"));
         assertThrows(TerminologyServicesException.class, () ->
                 terminologyLookupService.searchConcepts("Malaria", 10, null)
@@ -186,7 +198,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY/sct?fhir_vs=ecl/<<");
         when(administrationService.getGlobalProperty(TerminologyLookupService.DIAGNOSIS_COUNT_VALUE_SET_URL_TEMPLATE_GLOBAL_PROP)).thenReturn("ValueSet/$expand?url={0}{1}&displayLanguage={2}&count={3,number,#}&offset={4,number,#}");
         ValueSet valueSet = getMockValueSet();
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         ValueSet valueSetResponse = terminologyLookupService.searchTerminologyCodes("12345", 10, 0, "en");
         assertEquals(valueSet,valueSetResponse);
@@ -202,7 +216,9 @@ public class TerminologyLookupServiceImplTest {
         ValueSet valueSet = getMockValueSetForConcept();
         Concept mockConcept = getMockConcept();
 
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(vsConceptMapper.map(any(ValueSet.class))).thenReturn(mockConcept);
 
@@ -220,7 +236,9 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.OBSERVATION_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
-        when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        //when(fhirContext.newRestfulGenericClient(anyString())).thenReturn(iGenericClient);
+        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
+        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
         when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(vsSimpleObjectMapper.map(any(ValueSet.class))).thenReturn(simpleObjectSingletonList);
         List<SimpleObject> diagnosisSearchList = terminologyLookupService.searchConcepts("http://DUMMY_VALUESET_URL", null, null, null);

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImplTest.java
@@ -230,9 +230,11 @@ public class TerminologyLookupServiceImplTest {
         when(administrationService.getGlobalProperty(TerminologyLookupService.OBSERVATION_VALUE_SET_URL_GLOBAL_PROP)).thenReturn("http://DUMMY_VALUESET_URL");
         ValueSet valueSet = getMockValueSet();
         List<SimpleObject> simpleObjectSingletonList = getMockSimpleObjectSingletonList(valueSet);
+//        when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
         when(fhirContext.getRestfulClientFactory()).thenReturn(iRestfulClientFactory);
-        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
-        when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
+//        when(iRestfulClientFactory.newGenericClient(anyString())).thenReturn(iGenericClient);
+       // when(iGenericClient.read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
+        when(iRestfulClientFactory.newGenericClient(anyString()).read().resource(ValueSet.class).withUrl(anyString()).execute()).thenReturn(valueSet);
         when(vsSimpleObjectMapper.map(any(ValueSet.class))).thenReturn(simpleObjectSingletonList);
         List<SimpleObject> diagnosisSearchList = terminologyLookupService.searchConcepts("http://DUMMY_VALUESET_URL", null, null, null);
         assertNotNull(diagnosisSearchList);

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -63,17 +63,17 @@
 
     <globalProperty>
         <property>ts.fhir.valueset.socket.timeout</property>
-        <description>Specifies maximum amount of time in milliseconds a terminology server waits for a request before timeout</description>
+        <description>Client side setting that specifies maximum time between two data packets to arrive</description>
     </globalProperty>
 
     <globalProperty>
         <property>ts.fhir.valueset.connection.timeout</property>
-        <description>Specifies maximum amount of time that the application will wait while trying to establish a connection to a terminology server.</description>
+        <description>Client side setting that specifies the period between which the connection between a client and a server must be established</description>
     </globalProperty>
 
     <globalProperty>
         <property>ts.fhir.valueset.connection.request.timeout</property>
-        <description>Specifies maximum amount of time the applications waits for the terminology service to respond to its connection request and acknowledge the establishment of a connection</description>
+        <description>Specifies maximum time during which a connection must be obtained from the connection pool</description>
     </globalProperty>
 
     <messages>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -62,17 +62,17 @@
     </globalProperty>
 
     <globalProperty>
-        <property>ts.socket.timeout</property>
+        <property>ts.fhir.valueset.socket.timeout</property>
         <description>Specifies maximum amount of time in milliseconds a terminology server waits for a request before timeout</description>
     </globalProperty>
 
     <globalProperty>
-        <property>ts.connection.timeout</property>
+        <property>ts.fhir.valueset.connection.timeout</property>
         <description>Specifies maximum amount of time that the application will wait while trying to establish a connection to a terminology server.</description>
     </globalProperty>
 
     <globalProperty>
-        <property>ts.connection.request.timeout</property>
+        <property>ts.fhir.valueset.connection.request.timeout</property>
         <description>Specifies maximum amount of time the applications waits for the terminology service to respond to its connection request and acknowledge the establishment of a connection</description>
     </globalProperty>
 

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -61,6 +61,21 @@
         <description>URL template pattern for fetching valueset for procedure details from terminology server</description>
     </globalProperty>
 
+    <globalProperty>
+        <property>ts.socket.timeout</property>
+        <description>Specifies maximum amount of time in milliseconds a terminology server waits for a request before timeout</description>
+    </globalProperty>
+
+    <globalProperty>
+        <property>ts.connection.timeout</property>
+        <description>Specifies maximum amount of time that the application will wait while trying to establish a connection to a terminology server.</description>
+    </globalProperty>
+
+    <globalProperty>
+        <property>ts.connection.request.timeout</property>
+        <description>Specifies maximum amount of time the applications waits for the terminology service to respond to its connection request and acknowledge the establishment of a connection</description>
+    </globalProperty>
+
     <messages>
         <lang>en</lang>
         <file>messages.properties</file>


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [ ] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary
Extended the default request timeout for the IRestfulClient to cater to SNOMED reports that exhibit extended response times, particularly the clinical finding diagnosis (ICD) report.

## Screenshots
![clinicalFindings](https://github.com/Bahmni/openmrs-module-snomed/assets/16693480/2b3d0855-22d5-4f5e-ada8-53f366e940ef)


## JIRA tickets
https://bahmni.atlassian.net/browse/BS-178
