### PR TITLE
BS-65 | Syncing Procedures with Terminology Server Valueset

### DIFF
--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TSConceptService.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TSConceptService.java
@@ -36,6 +36,7 @@ public class TSConceptService extends TSConceptUuidResolver {
         Concept parentConceptForValueSet = getParentConceptForValueSet(valueSet.getName(), valueSet.getTitle(), CONV_SET, conceptDatatypeName);
         List<Concept> conceptList = getConceptList(conceptClassName, conceptDatatypeName, contains, parentConceptForValueSet);
         addNewMemberConceptToConceptSet(parentConceptForValueSet, contextRootConcept);
+        updateParentConceptSetMembers(parentConceptForValueSet, conceptList);
         return conceptList;
     }
 
@@ -60,5 +61,10 @@ public class TSConceptService extends TSConceptUuidResolver {
             logger.error("Context Root Concept " + contextRootConceptName + " should be a set");
             throw new APIException("Context Root Concept " + contextRootConceptName + " should be a set");
         }
+    }
+
+    private void updateParentConceptSetMembers(Concept parentConcept, List<Concept> currentSetMembers) {
+        parentConcept.getConceptSets().clear();
+        currentSetMembers.stream().forEach(parentConcept :: addSetMember);
     }
 }

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolver.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolver.java
@@ -91,7 +91,7 @@ public class TSConceptUuidResolver {
         if (existingAnswerConcept == null) {
             return getNewAnswerConcept(conceptClassName, conceptSet, conceptDatatypeName, conceptReferenceTermCode, conceptSource);
         }
-        updateExistingAnswerConceptInCurrentLocale(conceptClassName, conceptSet, conceptDatatypeName, conceptReferenceTermCode, existingAnswerConcept);
+        updateExistingConceptInCurrentLocale(conceptClassName, conceptSet, conceptDatatypeName, conceptReferenceTermCode, existingAnswerConcept);
         return existingAnswerConcept;
     }
 
@@ -195,10 +195,16 @@ public class TSConceptUuidResolver {
         return newAnswerConcept;
     }
 
-    private void updateExistingAnswerConceptInCurrentLocale(String conceptClassName, Concept conceptSet, String conceptDatatypeName, String conceptReferenceTermCode, Concept existingAnswerConcept) {
+    private void updateExistingConceptInCurrentLocale(String conceptClassName, Concept conceptSet, String conceptDatatypeName, String conceptReferenceTermCode, Concept existingAnswerConcept) {
         ConceptName answerConceptNameInUserLocale = existingAnswerConcept.getFullySpecifiedName(Context.getLocale());
         if (answerConceptNameInUserLocale == null)
             updateExistingConcept(existingAnswerConcept, conceptReferenceTermCode, conceptClassName, conceptDatatypeName);
+        else {
+            Concept conceptInUserLocale = getConcept(conceptReferenceTermCode, conceptClassName, conceptDatatypeName);
+            existingAnswerConcept.getFullySpecifiedName(Context.getLocale()).setName(conceptInUserLocale.getFullySpecifiedName(Context.getLocale()).getName());
+            if (conceptInUserLocale.getShortNameInLocale(Context.getLocale()) != null)
+                existingAnswerConcept.getShortNameInLocale(Context.getLocale()).setName(conceptInUserLocale.getShortNameInLocale(Context.getLocale()).getName());
+        }
         if (CONCEPT_CLASS_FINDINGS.equals(conceptClassName) && !checkIfConceptAnswerExistsForConceptSet(conceptSet, existingAnswerConcept.getConceptId())) {
             addNewAnswerToConceptSet(existingAnswerConcept, conceptSet);
         }

--- a/api/src/test/resources/mock/TsMockResponseForProceduresValueSetUpdated.json
+++ b/api/src/test/resources/mock/TsMockResponseForProceduresValueSetUpdated.json
@@ -1,0 +1,69 @@
+{
+  "resourceType": "ValueSet",
+  "id": "1a5d09c5-c658-42b4-bc09-05c55b621659",
+  "url": "http://example.com/fhir/ValueSet/bahmni-procedures-head4",
+  "version": "0.1",
+  "name": "bahmni-procedures-head",
+  "title": "Head",
+  "status": "draft",
+  "experimental": true,
+  "description": "List of possible procedures on the head",
+  "expansion": {
+    "id": "322f2841-6cd9-4890-9c18-5455d8537234",
+    "timestamp": "2023-05-03T05:00:00+05:30",
+    "total": 10,
+    "offset": 0,
+    "contains": [
+      {
+        "system": "http://dummyhost/dummysystemcode",
+        "code": "1001",
+        "display": "Reattachment of muscle"
+      },
+      {
+        "system": "http://dummyhost/dummysystemcode",
+        "code": "1002",
+        "display": "Application of vacuum assisted closure device to skin of head"
+      },
+      {
+        "system": "http://dummyhost/dummysystemcode",
+        "code": "1003",
+        "display": "Removal of suture from head"
+      },
+      {
+        "system": "http://dummyhost/dummysystemcode",
+        "code": "1004",
+        "display": "Change of splint"
+      },
+      {
+        "system": "http://dummyhost/dummysystemcode",
+        "code": "1005",
+        "display": "Immobilization by splinting"
+      },
+      {
+        "system": "http://dummyhost/dummysystemcode",
+        "code": "1006",
+        "display": "Ultrasonography of head and neck"
+      },
+      {
+        "system": "http://dummyhost/dummysystemcode",
+        "code": "1007",
+        "display": "Change of plaster cast"
+      },
+      {
+        "system": "http://dummyhost/dummysystemcode",
+        "code": "1008",
+        "display": "Immobilization using plaster cast"
+      },
+      {
+        "system": "http://dummyhost/dummysystemcode",
+        "code": "1009",
+        "display": "Removal of suture from skin of head or neck"
+      },
+      {
+        "system": "http://dummyhost/dummysystemcode",
+        "code": "1010",
+        "display": "Reattachment of Head muscle"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary

- Add / Delete Procedures’s from (SNOWSTORM) Valueset to Bahmni Procedure ConvSets
- Cascade Name changes of Procedure (SNOWSTORM) to Bahmni Concept

## Screenshots
<!-- Required if you are making UI changes. -->

## JIRA tickets
https://bahmni.atlassian.net/browse/BS-65

## Other
<!-- Anything not covered above -->