### PR TITLE
BS-289 | Adding TS Preferred Name as short name if short name missing in OpenMRS

### DIFF
--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolver.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolver.java
@@ -200,17 +200,17 @@ public class TSConceptUuidResolver {
         if (answerConceptNameInUserLocale == null)
             updateExistingConcept(existingAnswerConcept, conceptReferenceTermCode, conceptClassName, conceptDatatypeName);
         else {
-            addNamesAsSynonyms(conceptClassName, conceptDatatypeName, conceptReferenceTermCode, existingAnswerConcept);
+            addNamesFromTerminologyServer(conceptClassName, conceptDatatypeName, conceptReferenceTermCode, existingAnswerConcept);
         }
         if (CONCEPT_CLASS_FINDINGS.equals(conceptClassName) && !checkIfConceptAnswerExistsForConceptSet(conceptSet, existingAnswerConcept.getConceptId())) {
             addNewAnswerToConceptSet(existingAnswerConcept, conceptSet);
         }
     }
 
-    private void addNamesAsSynonyms(String conceptClassName, String conceptDatatypeName, String conceptReferenceTermCode, Concept existingConcept) {
+    private void addNamesFromTerminologyServer(String conceptClassName, String conceptDatatypeName, String conceptReferenceTermCode, Concept existingConcept) {
         Concept conceptInUserLocale = getConcept(conceptReferenceTermCode, conceptClassName, conceptDatatypeName);
         addTSFullySpecifiedNameAsSynonym(existingConcept, conceptInUserLocale);
-        addTSPreferredNameAsSynonym(existingConcept, conceptInUserLocale);
+        addTSPreferredName(existingConcept, conceptInUserLocale);
     }
 
     private void addTSFullySpecifiedNameAsSynonym(Concept existingConcept, Concept conceptInUserLocale) {
@@ -223,8 +223,13 @@ public class TSConceptUuidResolver {
         }
     }
 
-    private void addTSPreferredNameAsSynonym(Concept existingConcept, Concept conceptInUserLocale) {
+    private void addTSPreferredName(Concept existingConcept, Concept conceptInUserLocale) {
         if (conceptInUserLocale.getShortNameInLocale(Context.getLocale()) == null) {
+            return;
+        }
+        if (existingConcept.getShortNameInLocale(Context.getLocale()) == null) {
+            ConceptName shortNameInLocale = conceptInUserLocale.getShortNameInLocale(Context.getLocale());
+            existingConcept.setShortName(shortNameInLocale);
             return;
         }
         Collection<ConceptName> existingConceptNames = existingConcept.getNames();


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary
Let's say for example, In SNOMED Clinic, for Malaria concept,
        FSN=Malaria   Synonym=<EMPTY>   ShortName=<EMPTY>
After Concept Name Resolution with SNOMED, the updates would be
       FSN=Malaria   Synonym=Malaria(disorder)   ShortName=Malaria
Logic would be
     if FSN is already present in existing Concept, then move the SNOMED FSN to Synonym.
     if ShortName is already present in existing Concept, then move the SNOMED ShortName to Synonym

## Screenshots
<!-- Required if you are making UI changes. -->

## JIRA tickets
https://bahmni.atlassian.net/browse/BS-289

## Other
<!-- Anything not covered above -->