### PR TITLE
BS-262 | Fix. Remove concrete dependency on ValueSetTask in TerminologyLookupController

### DIFF
--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/task/ValueSetTask.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/task/ValueSetTask.java
@@ -1,79 +1,13 @@
 package org.bahmni.module.fhirterminologyservices.api.task;
 
-import org.apache.log4j.Logger;
-import org.bahmni.module.fhirterminologyservices.api.TSConceptService;
-import org.bahmni.module.fhirterminologyservices.api.TerminologyLookupService;
-import org.hl7.fhir.r4.model.ValueSet;
-import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
-import org.openmrs.module.fhir2.api.dao.FhirTaskDao;
 import org.openmrs.module.fhir2.model.FhirTask;
-import org.openmrs.module.webservices.rest.web.RestUtil;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Component
-@Transactional
-public class ValueSetTask {
-
-    private TerminologyLookupService terminologyLookupService;
-    private TSConceptService tsConceptService;
-    private FhirTaskDao fhirTaskDao;
-
-    @Autowired
-    public ValueSetTask(TerminologyLookupService terminologyLookupService, TSConceptService tsConceptService, FhirTaskDao fhirTaskDao) {
-        this.terminologyLookupService = terminologyLookupService;
-        this.tsConceptService = tsConceptService;
-        this.fhirTaskDao = fhirTaskDao;
-    }
-
-    private static Logger logger = Logger.getLogger(ValueSetTask.class);
-
-    public FhirTask getInitialTaskResponse(List<String> valueSetIds) {
-        FhirTask fhirTask = new FhirTask();
-        fhirTask.setStatus(FhirTask.TaskStatus.ACCEPTED);
-        fhirTask.setName("Create / Update Value Set");
-        logger.info("Create / Update Value Sets for " + valueSetIds);
-        fhirTask.setIntent(FhirTask.TaskIntent.ORDER);
-        fhirTaskDao.createOrUpdate(fhirTask);
-        return fhirTask;
-    }
-
-    @Async("threadPoolTaskExecutor")
-    public void convertValueSetsToConceptsTask(List<String> valueSetIds, String locale, String conceptClass, String conceptDatatype, String contextRoot, FhirTask fhirTask, UserContext userContext) {
-        FhirTask.TaskStatus taskStatus = null;
-        try {
-            Context.openSession();
-            Context.setUserContext(userContext);
-            valueSetIds.stream().forEach(valueSetId -> {
-                Integer pageSize = RestUtil.getDefaultLimit();
-                int offset = 0;
-                int total = 0;
-                do {
-                    ValueSet valueSet = terminologyLookupService.getValueSetByPageSize(valueSetId, locale, pageSize, offset);
-                    total = valueSet.getExpansion().getTotal();
-                    if (total == 0 && !valueSetId.equals(valueSet.getName())) {
-                        logger.info("Value set " + valueSetId + " not found");
-                        tsConceptService.removeMemberFromConceptSet(contextRoot, valueSetId);
-                        break;
-                    }
-                    offset += pageSize;
-                    tsConceptService.createOrUpdateConceptsForValueSet(valueSet, conceptClass, conceptDatatype, contextRoot);
-                } while (offset < total);
-            });
-        } catch (Exception exception) {
-            taskStatus = FhirTask.TaskStatus.REJECTED;
-            logger.error("Exception occurred while processing value sets ", exception);
-        } finally {
-            if (taskStatus == null) {
-                taskStatus = FhirTask.TaskStatus.COMPLETED;
-            }
-            fhirTask.setStatus(taskStatus);
-            fhirTaskDao.createOrUpdate(fhirTask);
-        }
-    }
+public interface ValueSetTask {
+    FhirTask getInitialTaskResponse(List<String> valueSetIds);
+    void convertValueSetsToConceptsTask(List<String> valueSetIds, String locale,
+                                        String conceptClass, String conceptDatatype,
+                                        String contextRoot, FhirTask task, UserContext userContext);
 }

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/task/impl/ValueSetTaskImpl.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/task/impl/ValueSetTaskImpl.java
@@ -1,0 +1,82 @@
+package org.bahmni.module.fhirterminologyservices.api.task.impl;
+
+import org.apache.log4j.Logger;
+import org.bahmni.module.fhirterminologyservices.api.TSConceptService;
+import org.bahmni.module.fhirterminologyservices.api.TerminologyLookupService;
+import org.bahmni.module.fhirterminologyservices.api.task.ValueSetTask;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.UserContext;
+import org.openmrs.module.fhir2.api.dao.FhirTaskDao;
+import org.openmrs.module.fhir2.model.FhirTask;
+import org.openmrs.module.webservices.rest.web.RestUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@Transactional
+public class ValueSetTaskImpl implements ValueSetTask {
+
+    private TerminologyLookupService terminologyLookupService;
+    private TSConceptService tsConceptService;
+    private FhirTaskDao fhirTaskDao;
+
+    @Autowired
+    public ValueSetTaskImpl(TerminologyLookupService terminologyLookupService, TSConceptService tsConceptService, FhirTaskDao fhirTaskDao) {
+        this.terminologyLookupService = terminologyLookupService;
+        this.tsConceptService = tsConceptService;
+        this.fhirTaskDao = fhirTaskDao;
+    }
+
+    private static Logger logger = Logger.getLogger(ValueSetTaskImpl.class);
+
+    @Override
+    public FhirTask getInitialTaskResponse(List<String> valueSetIds) {
+        FhirTask fhirTask = new FhirTask();
+        fhirTask.setStatus(FhirTask.TaskStatus.ACCEPTED);
+        fhirTask.setName("Create / Update Value Set");
+        logger.info("Create / Update Value Sets for " + valueSetIds);
+        fhirTask.setIntent(FhirTask.TaskIntent.ORDER);
+        fhirTaskDao.createOrUpdate(fhirTask);
+        return fhirTask;
+    }
+
+    @Override
+    @Async("threadPoolTaskExecutor")
+    public void convertValueSetsToConceptsTask(List<String> valueSetIds, String locale, String conceptClass, String conceptDatatype, String contextRoot, FhirTask fhirTask, UserContext userContext) {
+        FhirTask.TaskStatus taskStatus = null;
+        try {
+            Context.openSession();
+            Context.setUserContext(userContext);
+            valueSetIds.stream().forEach(valueSetId -> {
+                Integer pageSize = RestUtil.getDefaultLimit();
+                int offset = 0;
+                int total = 0;
+                do {
+                    ValueSet valueSet = terminologyLookupService.getValueSetByPageSize(valueSetId, locale, pageSize, offset);
+                    total = valueSet.getExpansion().getTotal();
+                    if (total == 0 && !valueSetId.equals(valueSet.getName())) {
+                        logger.info("Value set " + valueSetId + " not found");
+                        tsConceptService.removeMemberFromConceptSet(contextRoot, valueSetId);
+                        break;
+                    }
+                    offset += pageSize;
+                    tsConceptService.createOrUpdateConceptsForValueSet(valueSet, conceptClass, conceptDatatype, contextRoot);
+                } while (offset < total);
+            });
+        } catch (Exception exception) {
+            taskStatus = FhirTask.TaskStatus.REJECTED;
+            logger.error("Exception occurred while processing value sets ", exception);
+        } finally {
+            if (taskStatus == null) {
+                taskStatus = FhirTask.TaskStatus.COMPLETED;
+            }
+            fhirTask.setStatus(taskStatus);
+            fhirTaskDao.createOrUpdate(fhirTask);
+        }
+    }
+}

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/task/ValueSetTaskImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/task/ValueSetTaskImplTest.java
@@ -3,6 +3,7 @@ package org.bahmni.module.fhirterminologyservices.api.task;
 import ca.uhn.fhir.context.FhirContext;
 import org.bahmni.module.fhirterminologyservices.api.TSConceptService;
 import org.bahmni.module.fhirterminologyservices.api.TerminologyLookupService;
+import org.bahmni.module.fhirterminologyservices.api.task.impl.ValueSetTaskImpl;
 import org.bahmni.module.fhirterminologyservices.utils.TerminologyServicesException;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.Assert;
@@ -42,7 +43,7 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Context.class)
 @PowerMockIgnore("javax.management.*")
-public class ValueSetTaskTest {
+public class ValueSetTaskImplTest {
 
     @Mock
     private TerminologyLookupService terminologyLookupService;
@@ -54,7 +55,7 @@ public class ValueSetTaskTest {
     private FhirTaskDao fhirTaskDao;
 
     @InjectMocks
-    private ValueSetTask valueSetTask;
+    private ValueSetTaskImpl valueSetTask;
 
     @Mock
     @Qualifier("adminService")


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary
This PR resolves the issue with OpenMRS service failing to start due to concrete dependency of ValueSetTask on TerminlogyLookupController

## JIRA tickets
[BS-262](https://bahmni.atlassian.net/browse/BS-262)

