### PR TITLE
BAH- 4811 | Snomed upgrade versions

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -44,18 +44,6 @@
             <groupId>org.openmrs.module</groupId>
             <artifactId>emrapi-api</artifactId>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.openmrs.module</groupId>-->
-<!--            <artifactId>emrapi-api-1.12</artifactId>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.openmrs.module</groupId>-->
-<!--            <artifactId>emrapi-condition-list</artifactId>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.openmrs.module</groupId>-->
-<!--            <artifactId>emrapi-web-2.2</artifactId>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -44,18 +44,18 @@
             <groupId>org.openmrs.module</groupId>
             <artifactId>emrapi-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.openmrs.module</groupId>
-            <artifactId>emrapi-api-1.12</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openmrs.module</groupId>
-            <artifactId>emrapi-condition-list</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openmrs.module</groupId>
-            <artifactId>emrapi-web-2.2</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.openmrs.module</groupId>-->
+<!--            <artifactId>emrapi-api-1.12</artifactId>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.openmrs.module</groupId>-->
+<!--            <artifactId>emrapi-condition-list</artifactId>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.openmrs.module</groupId>-->
+<!--            <artifactId>emrapi-web-2.2</artifactId>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/ConditionConceptSaveService.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/ConditionConceptSaveService.java
@@ -11,6 +11,6 @@ package org.bahmni.module.fhirterminologyservices.api;
 
 // todo refactor the class name and its implementation
 public interface ConditionConceptSaveService {
-    org.openmrs.module.emrapi.conditionslist.contract.Condition update(org.openmrs.module.emrapi.conditionslist.contract.Condition condition );
+    org.openmrs.Condition update(org.openmrs.Condition condition );
 
 }

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolver.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolver.java
@@ -60,7 +60,7 @@ public class TSConceptUuidResolver {
     }
 
 
-    protected void resolveConceptUuid(org.openmrs.module.emrapi.conditionslist.contract.Concept codedAnswer, String conceptClassName, Concept conceptSet, String conceptDatatypeName) {
+    protected void resolveConceptUuid(org.openmrs.Concept codedAnswer, String conceptClassName, Concept conceptSet, String conceptDatatypeName) {
         String codedAnswerUuidWithSystem = codedAnswer.getUuid();
         String updatedConceptUuid = getUpdatedConceptUuid(codedAnswerUuidWithSystem, conceptClassName, conceptSet, conceptDatatypeName);
         codedAnswer.setUuid(updatedConceptUuid);

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/ConditionConceptSaveImpl.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/ConditionConceptSaveImpl.java
@@ -36,14 +36,14 @@ public class ConditionConceptSaveImpl extends TSConceptUuidResolver implements C
     }
 
     @Override
-    public org.openmrs.module.emrapi.conditionslist.contract.Condition update(org.openmrs.module.emrapi.conditionslist.contract.Condition condition) {
+    public org.openmrs.Condition update(org.openmrs.Condition condition) {
         updateConditionAnswerConceptUuid(condition);
         return condition;
     }
 
-    private void updateConditionAnswerConceptUuid(org.openmrs.module.emrapi.conditionslist.contract.Condition condition) {
+    private void updateConditionAnswerConceptUuid(org.openmrs.Condition condition) {
         String codedConceptUuid = adminService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID);
-        org.openmrs.module.emrapi.conditionslist.contract.Concept codedAnswer = condition.getConcept();
+        org.openmrs.Concept codedAnswer = condition.getCondition() != null ? condition.getCondition().getCoded() : null;
         if (!(codedAnswer != null && codedAnswer.getUuid() != null)) {
             return;
         }

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/api/impl/TerminologyLookupServiceImpl.java
@@ -11,6 +11,7 @@ package org.bahmni.module.fhirterminologyservices.api.impl;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
 import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.UnclassifiedServerFailureException;
@@ -47,6 +48,7 @@ public class TerminologyLookupServiceImpl extends BaseOpenmrsService implements 
     public TerminologyLookupServiceImpl(ValueSetMapper<List<SimpleObject>> vsSimpleObjectMapper, ValueSetMapper<Concept> vsConceptMapper) {
         this.vsSimpleObjectMapper = vsSimpleObjectMapper;
         this.vsConceptMapper = vsConceptMapper;
+        fhirContext.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
     }
 
     @Override

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/interceptor/EmrConditionControllerAdvice.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/interceptor/EmrConditionControllerAdvice.java
@@ -50,13 +50,11 @@ public class EmrConditionControllerAdvice implements RequestBodyAdvice {
     @Override
     public boolean supports(MethodParameter methodParameter, Type targetType,
             Class<? extends HttpMessageConverter<?>> converterType) {
-        HttpServletRequest request = ((ServletRequestAttributes)
-                RequestContextHolder.getRequestAttributes()).getRequest();
-        boolean matched = "POST".equals(request.getMethod())
+        ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attrs == null) return false;
+        HttpServletRequest request = attrs.getRequest();
+        return "POST".equals(request.getMethod())
                 && request.getRequestURI().contains("/ws/rest/v1/condition");
-        logger.info("In supports() of " + getClass().getSimpleName()
-                + " — " + request.getMethod() + " " + request.getRequestURI() + " → matched=" + matched);
-        return matched;
     }
 
     @Override

--- a/api/src/main/java/org/bahmni/module/fhirterminologyservices/interceptor/EmrConditionControllerAdvice.java
+++ b/api/src/main/java/org/bahmni/module/fhirterminologyservices/interceptor/EmrConditionControllerAdvice.java
@@ -14,30 +14,33 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.bahmni.module.fhirterminologyservices.api.ConditionConceptSaveService;
-import org.openmrs.module.emrapi.conditionslist.contract.Condition;
+import org.openmrs.CodedOrFreeText;
+import org.openmrs.Concept;
+import org.openmrs.Condition;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJacksonInputMessage;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdvice;
 import org.springframework.http.HttpInputMessage;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.util.Map;
 
-@ControllerAdvice(assignableTypes = {org.openmrs.module.emrapi.web.controller.ConditionController.class})
+@ControllerAdvice(assignableTypes = {MainResourceController.class})
 public class EmrConditionControllerAdvice implements RequestBodyAdvice {
     private static Logger logger = Logger.getLogger(EmrConditionControllerAdvice.class);
 
     ConditionConceptSaveService conditionConceptSaveService;
-
-    private static final String SAVE_METHOD = "save";
-
 
     @Autowired
     public void setConditionConceptSaveService (ConditionConceptSaveService conditionConceptSaveService) {
@@ -45,10 +48,15 @@ public class EmrConditionControllerAdvice implements RequestBodyAdvice {
     }
 
     @Override
-    public boolean supports(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
-        logger.info("In supports() method of " + getClass().getSimpleName());
-        boolean isSupported  = SAVE_METHOD.equals(methodParameter.getMethod().getName());
-        return isSupported;
+    public boolean supports(MethodParameter methodParameter, Type targetType,
+            Class<? extends HttpMessageConverter<?>> converterType) {
+        HttpServletRequest request = ((ServletRequestAttributes)
+                RequestContextHolder.getRequestAttributes()).getRequest();
+        boolean matched = "POST".equals(request.getMethod())
+                && request.getRequestURI().contains("/ws/rest/v1/condition");
+        logger.info("In supports() of " + getClass().getSimpleName()
+                + " — " + request.getMethod() + " " + request.getRequestURI() + " → matched=" + matched);
+        return matched;
     }
 
     @Override
@@ -57,11 +65,25 @@ public class EmrConditionControllerAdvice implements RequestBodyAdvice {
         ObjectMapper objectMapper = new ObjectMapper();
 
         String bodyStr = IOUtils.toString(body, Charset.forName("UTF-8"));
-        Condition[] conditionList =  objectMapper
-                .readValue(bodyStr, new TypeReference<Condition[]>() {
-                });
-        Arrays.stream(conditionList).forEach(condition -> conditionConceptSaveService.update(condition));
-        bodyStr = objectMapper.writeValueAsString(conditionList);
+        Map<String, Object> bodyMap = objectMapper.readValue(bodyStr, new TypeReference<Map<String, Object>>() {});
+
+        Object conditionField = bodyMap.get("condition");
+        if (conditionField instanceof Map) {
+            Map conditionMap = (Map) conditionField;
+            Object codedUuid = conditionMap.get("coded");
+            if (codedUuid != null) {
+                Concept codedConcept = new Concept();
+                codedConcept.setUuid(codedUuid.toString());
+                CodedOrFreeText codedOrFreeText = new CodedOrFreeText();
+                codedOrFreeText.setCoded(codedConcept);
+                Condition condition = new Condition();
+                condition.setCondition(codedOrFreeText);
+                conditionConceptSaveService.update(condition);
+                conditionMap.put("coded", condition.getCondition().getCoded().getUuid());
+            }
+        }
+
+        bodyStr = objectMapper.writeValueAsString(bodyMap);
         return new MappingJacksonInputMessage(new ByteArrayInputStream(bodyStr.getBytes()), httpInputMessage.getHeaders());
     }
 

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -11,7 +11,7 @@
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:util="http://www.springframework.org/schema/util" xmlns:mvc="http://www.springframework.org/schema/c"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-  		    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+  		    http://www.springframework.org/schema/beans/spring-beans.xsd
   		    http://www.springframework.org/schema/context
   		    http://www.springframework.org/schema/context/spring-context-3.0.xsd
   		    http://www.springframework.org/schema/jee

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolverTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/TSConceptUuidResolverTest.java
@@ -97,7 +97,7 @@ public class TSConceptUuidResolverTest {
     public void shouldUpdateConceptUuidAndSaveNewDiagnosisAnswerConceptAndAddToUnclassifiedSetWhenConceptSourceAndReferenceCodeProvidedForCondition() {
         Concept newDiagnosisConcept = getDiagnosisConcept();
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
-        org.openmrs.module.emrapi.conditionslist.contract.Concept concept = getBahmniConditionConcept(MOCK_CONCEPT_SYSTEM, true);
+        org.openmrs.Concept concept = getBahmniConditionConcept(MOCK_CONCEPT_SYSTEM, true);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
         when(conceptService.getConceptByUuid(UNCLASSIFIED_CONCEPT_SET_UUID)).thenReturn(unclassifiedConceptSet);
@@ -115,7 +115,7 @@ public class TSConceptUuidResolverTest {
     public void shouldUpdateConceptUuidAndNotCreateDiagnosisAnswerConceptWhenExistingConceptSourceAndCodeProvidedForCondition() {
         Concept existingDiagnosisConcept = getDiagnosisConcept();
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
-        org.openmrs.module.emrapi.conditionslist.contract.Concept concept = getBahmniConditionConcept(MOCK_CONCEPT_SYSTEM, true);
+        org.openmrs.Concept concept = getBahmniConditionConcept(MOCK_CONCEPT_SYSTEM, true);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
         List<Concept> mockConceptList = getMockConceptList(true);
         when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConceptList);
@@ -137,7 +137,7 @@ public class TSConceptUuidResolverTest {
     public void shouldNotUpdateConceptUuidAndNotCreateDiagnosisAnswerConceptWhenReferenceCodeNotProvidedForCondition() {
         Concept existingDiagnosisConcept = getDiagnosisConcept();
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
-        org.openmrs.module.emrapi.conditionslist.contract.Concept concept = getBahmniConditionConcept(MOCK_CONCEPT_SYSTEM, false);
+        org.openmrs.Concept concept = getBahmniConditionConcept(MOCK_CONCEPT_SYSTEM, false);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
         when(conceptService.getConceptByMapping(anyString(), anyString())).thenReturn(existingDiagnosisConcept);
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
@@ -267,18 +267,19 @@ public class TSConceptUuidResolverTest {
 
     // private methods for conidition
 
-    private org.openmrs.module.emrapi.conditionslist.contract.Concept getBahmniConditionConcept(String conceptSystem, boolean isCodedAnswerFromTerminologyServer) {
+    private  org.openmrs.Concept getBahmniConditionConcept(String conceptSystem, boolean isCodedAnswerFromTerminologyServer) {
         return createBahmniConditionConcept(conceptSystem, isCodedAnswerFromTerminologyServer);
     }
 
-    private org.openmrs.module.emrapi.conditionslist.contract.Concept createBahmniConditionConcept(String conceptSystem, boolean isCodedAnswerFromTerminologyServer) {
-        String codedAnswerUuid = null;
-        String conceptName = "dummy-concept";
+    private  org.openmrs.Concept createBahmniConditionConcept(String conceptSystem, boolean isCodedAnswerFromTerminologyServer) {
+        String codedAnswerUuid;
         if (isCodedAnswerFromTerminologyServer)
             codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "dummyConceptCode";
         else
             codedAnswerUuid = "coded-answer-uuid";
-        return new org.openmrs.module.emrapi.conditionslist.contract.Concept(codedAnswerUuid, conceptName);
+        org.openmrs.Concept concept = new org.openmrs.Concept();
+        concept.setUuid(codedAnswerUuid);
+        return concept;
     }
 
     // common private methods for diagnosis and condition

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/ConditionConceptSaveImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/impl/ConditionConceptSaveImplTest.java
@@ -17,6 +17,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.openmrs.CodedOrFreeText;
 import org.openmrs.Concept;
 import org.openmrs.ConceptMap;
 import org.openmrs.ConceptMapType;
@@ -87,7 +88,7 @@ public class ConditionConceptSaveImplTest {
     public void shouldSaveNewConditionAnswerConceptAndAddToUnclassifiedSetWhenConceptSourceAndReferenceCodeProvided() {
         Concept newDiagnosisConcept = getDiagnosisConcept();
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
-        org.openmrs.module.emrapi.conditionslist.contract.Condition condition = getBahmniCondition(MOCK_CONCEPT_SYSTEM, true);
+        org.openmrs.Condition condition = getBahmniCondition(MOCK_CONCEPT_SYSTEM, true);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
         when(conceptService.getConceptByUuid(UNCLASSIFIED_CONCEPT_SET_UUID)).thenReturn(unclassifiedConceptSet);
@@ -98,14 +99,14 @@ public class ConditionConceptSaveImplTest {
         conditionConceptSave.update(condition);
 
         assertEquals(initialDiagnosisSetMembersCount + 1, unclassifiedConceptSet.getSetMembers().size());
-        assertEquals(MALARIA_CONCEPT_UUID, condition.getConcept().getUuid());
+        assertEquals(MALARIA_CONCEPT_UUID, condition.getCondition().getCoded().getUuid());
     }
 
     @Test
     public void shouldNotCreateDiagnosisAnswerConceptWhenExistingConceptProvided() {
         Concept newDiagnosisConcept = getDiagnosisConcept();
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
-        org.openmrs.module.emrapi.conditionslist.contract.Condition condition = getBahmniCondition(MOCK_CONCEPT_SYSTEM, false);
+        org.openmrs.Condition condition = getBahmniCondition(MOCK_CONCEPT_SYSTEM, false);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
         when(conceptService.getConceptByUuid(UNCLASSIFIED_CONCEPT_SET_UUID)).thenReturn(unclassifiedConceptSet);
@@ -123,7 +124,7 @@ public class ConditionConceptSaveImplTest {
     public void shouldNotCreateDiagnosisAnswerConceptWhenExistingConceptSourceAndCodeProvided() {
         Concept existingDiagnosisConcept = getDiagnosisConcept();
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
-        org.openmrs.module.emrapi.conditionslist.contract.Condition condition = getBahmniCondition(MOCK_CONCEPT_SYSTEM, true);
+        org.openmrs.Condition condition = getBahmniCondition(MOCK_CONCEPT_SYSTEM, true);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
         List<Concept> mockConceptList = getMockConceptList(true);
         when(conceptService.getConceptsByMapping(anyString(), anyString())).thenReturn(mockConceptList);
@@ -138,14 +139,14 @@ public class ConditionConceptSaveImplTest {
 
         assertEquals(initialDiagnosisSetMembersCount, unclassifiedConceptSet.getSetMembers().size());
         verify(conceptService, times(0)).saveConcept(any(Concept.class));
-        assertEquals(MALARIA_CONCEPT_UUID, condition.getConcept().getUuid());
+        assertEquals(MALARIA_CONCEPT_UUID, condition.getCondition().getCoded().getUuid());
     }
 
     @Test
     public void shouldThrowExceptionWhenConceptSourceNotFound() {
         Concept newDiagnosisConcept = getDiagnosisConcept();
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
-        org.openmrs.module.emrapi.conditionslist.contract.Condition condition = getBahmniCondition("Some Invalid System", true);
+        org.openmrs.Condition condition = getBahmniCondition("Some Invalid System", true);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.empty());
         when(conceptService.getConceptByUuid(UNCLASSIFIED_CONCEPT_SET_UUID)).thenReturn(unclassifiedConceptSet);
@@ -164,7 +165,7 @@ public class ConditionConceptSaveImplTest {
     @Test
     public void shouldThrowExceptionWhenTerminologyServerUnavailable() {
         Concept unclassifiedConceptSet = getUnclassifiedConceptSet();
-        org.openmrs.module.emrapi.conditionslist.contract.Condition condition = getBahmniCondition(MOCK_CONCEPT_SYSTEM, true);
+        org.openmrs.Condition condition = getBahmniCondition(MOCK_CONCEPT_SYSTEM, true);
         when(administrationService.getGlobalProperty(GP_DEFAULT_CONCEPT_SET_FOR_DIAGNOSIS_CONCEPT_UUID)).thenReturn(UNCLASSIFIED_CONCEPT_SET_UUID);
         when(conceptSourceService.getConceptSourceByUrl(anyString())).thenReturn(Optional.of(getMockedConceptSources(MOCK_CONCEPT_SYSTEM, MOCK_CONCEPT_SOURCE_CODE)));
         when(conceptService.getConceptByUuid(UNCLASSIFIED_CONCEPT_SET_UUID)).thenReturn(unclassifiedConceptSet);
@@ -184,19 +185,22 @@ public class ConditionConceptSaveImplTest {
     }
 
 
-    private org.openmrs.module.emrapi.conditionslist.contract.Condition getBahmniCondition(String conceptSystem, boolean isCodedAnswerFromTermimologyServer) {
+    private org.openmrs.Condition getBahmniCondition(String conceptSystem, boolean isCodedAnswerFromTermimologyServer) {
         return createBahmniCondition(conceptSystem, isCodedAnswerFromTermimologyServer);
     }
 
-    private org.openmrs.module.emrapi.conditionslist.contract.Condition createBahmniCondition(String conceptSystem, boolean isCodedAnswerFromTermimologyServer) {
-        String codedAnswerUuid = null;
-        String conceptName = "dummy-concept";
+    private org.openmrs.Condition createBahmniCondition(String conceptSystem, boolean isCodedAnswerFromTermimologyServer) {
+        String codedAnswerUuid;
         if (isCodedAnswerFromTermimologyServer)
             codedAnswerUuid = conceptSystem + TERMINOLOGY_SERVER_CODED_ANSWER_DELIMITER + "dummyConceptCode";
         else
             codedAnswerUuid = "coded-answer-uuid";
-        org.openmrs.module.emrapi.conditionslist.contract.Condition condition = new org.openmrs.module.emrapi.conditionslist.contract.Condition();
-        condition.setConcept(new org.openmrs.module.emrapi.conditionslist.contract.Concept(codedAnswerUuid, conceptName));
+        org.openmrs.Concept codedConcept = new org.openmrs.Concept();
+        codedConcept.setUuid(codedAnswerUuid);
+        CodedOrFreeText codedOrFreeText = new CodedOrFreeText();
+        codedOrFreeText.setCoded(codedConcept);
+        org.openmrs.Condition condition = new org.openmrs.Condition();
+        condition.setCondition(codedOrFreeText);
         condition.setAdditionalDetail("comments");
         return condition;
     }

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/task/ValueSetTaskImplTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/api/task/ValueSetTaskImplTest.java
@@ -96,6 +96,7 @@ public class ValueSetTaskImplTest {
         FhirTask initialTaskResponse = valueSetTask.getInitialTaskResponse(valueSetIds);
         ValueSet mockValueSet = getMockValueSet();
         when(administrationService.getGlobalProperty(RestConstants.MAX_RESULTS_DEFAULT_GLOBAL_PROPERTY_NAME)).thenReturn("50");
+        when(administrationService.getGlobalProperty(RestConstants.MAX_RESULTS_DEFAULT_GLOBAL_PROPERTY_NAME, null)).thenReturn("50");
         when(terminologyLookupService.getValueSetByPageSize("procedure-set-1", "en", 50, 0)).thenReturn(mockValueSet);
 
         valueSetTask.convertValueSetsToConceptsTask(valueSetIds, "en", "Procedure", "N/A", "Procedure Orders", initialTaskResponse, Context.getUserContext());
@@ -110,6 +111,7 @@ public class ValueSetTaskImplTest {
         FhirTask initialTaskResponse = valueSetTask.getInitialTaskResponse(valueSetIds);
         ValueSet mockValueSet = getMockValueSet();
         when(administrationService.getGlobalProperty(RestConstants.MAX_RESULTS_DEFAULT_GLOBAL_PROPERTY_NAME)).thenReturn("2");
+        when(administrationService.getGlobalProperty(RestConstants.MAX_RESULTS_DEFAULT_GLOBAL_PROPERTY_NAME, null)).thenReturn("2");
         when(terminologyLookupService.getValueSetByPageSize(anyString(), anyString(), anyInt(), anyInt())).thenReturn(mockValueSet);
 
         valueSetTask.convertValueSetsToConceptsTask(valueSetIds, "en", "Procedure", "N/A", "Procedure Orders", initialTaskResponse, Context.getUserContext());
@@ -124,6 +126,7 @@ public class ValueSetTaskImplTest {
         List<String> valueSetIds = Collections.singletonList("random-valueset-uuid-1");
         FhirTask initialTaskResponse = valueSetTask.getInitialTaskResponse(valueSetIds);
         when(administrationService.getGlobalProperty(RestConstants.MAX_RESULTS_DEFAULT_GLOBAL_PROPERTY_NAME)).thenReturn("50");
+        when(administrationService.getGlobalProperty(RestConstants.MAX_RESULTS_DEFAULT_GLOBAL_PROPERTY_NAME, null)).thenReturn("50");
         when(terminologyLookupService.getValueSetByPageSize("random-valueset-uuid-1", "en", 50, 0)).thenThrow(TerminologyServicesException.class);
 
         valueSetTask.convertValueSetsToConceptsTask(valueSetIds, "en", "Procedure", "N/A", "Procedure Orders", initialTaskResponse, Context.getUserContext());
@@ -137,6 +140,7 @@ public class ValueSetTaskImplTest {
         List<String> valueSetIds = Collections.singletonList("random-valueset-uuid-1");
         FhirTask initialTaskResponse = valueSetTask.getInitialTaskResponse(valueSetIds);
         when(administrationService.getGlobalProperty(RestConstants.MAX_RESULTS_DEFAULT_GLOBAL_PROPERTY_NAME)).thenReturn("50");
+        when(administrationService.getGlobalProperty(RestConstants.MAX_RESULTS_DEFAULT_GLOBAL_PROPERTY_NAME, null)).thenReturn("50");
         ValueSet emptyValueSet = getEmptyValueSet();
         when(terminologyLookupService.getValueSetByPageSize("random-valueset-uuid-1", "en", 50, 0)).thenReturn(emptyValueSet);
         valueSetTask.convertValueSetsToConceptsTask(valueSetIds, "en", "Procedure", "N/A", "Procedure Orders", initialTaskResponse, Context.getUserContext());

--- a/api/src/test/java/org/bahmni/module/fhirterminologyservices/interceptor/EmrConditionControllerAdviceTest.java
+++ b/api/src/test/java/org/bahmni/module/fhirterminologyservices/interceptor/EmrConditionControllerAdviceTest.java
@@ -9,65 +9,66 @@
 
 package org.bahmni.module.fhirterminologyservices.interceptor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bahmni.module.fhirterminologyservices.api.ConditionConceptSaveService;
-import org.junit.Before;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.openmrs.api.context.Context;
-import org.openmrs.module.emrapi.conditionslist.contract.Condition;
-import org.openmrs.module.emrapi.web.controller.ConditionController;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.springframework.core.MethodParameter;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openmrs.Condition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.converter.json.MappingJacksonInputMessage;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.lang.reflect.Method;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(Context.class)
-@PowerMockIgnore("javax.management.*")
+@RunWith(MockitoJUnitRunner.class)
 public class EmrConditionControllerAdviceTest {
 
     @InjectMocks
     EmrConditionControllerAdvice emrConditionControllerAdvice;
+
     @Mock
     ConditionConceptSaveService conditionConceptSaveService;
 
-    @Before
-    public void setUp() {
-        PowerMockito.mockStatic(Context.class);
+    @After
+    public void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
     }
+
     @Test
-    public  void shouldReturnTrueWhenInterceptedMethodNameMatchesSaveMethodName() throws NoSuchMethodException {
-        Method method = ConditionController.class.getMethod("save", Condition[].class);
-        MethodParameter methodParameter = new MethodParameter(method, 0);
-        boolean supports = emrConditionControllerAdvice.supports(methodParameter, null, null);
-        assertTrue(supports);
+    public void shouldReturnTrueForPostRequestToConditionEndpoint() {
+        setRequestContext("POST", "/ws/rest/v1/condition");
+        assertTrue(emrConditionControllerAdvice.supports(null, null, null));
     }
+
     @Test
-    public  void shouldReturnFalseWhenInterceptedMethodNameDoesntMatcheSaveMethodName() throws NoSuchMethodException {
-        Method method = ConditionController.class.getMethod("getConditionHistory", String.class);
-        MethodParameter methodParameter = new MethodParameter(method, 0);
-        boolean supports = emrConditionControllerAdvice.supports(methodParameter, null, null);
-        assertFalse(supports);
+    public void shouldReturnFalseForGetRequestToConditionEndpoint() {
+        setRequestContext("GET", "/ws/rest/v1/condition");
+        assertFalse(emrConditionControllerAdvice.supports(null, null, null));
     }
+
+    @Test
+    public void shouldReturnFalseForPostRequestToNonConditionEndpoint() {
+        setRequestContext("POST", "/ws/rest/v1/patient");
+        assertFalse(emrConditionControllerAdvice.supports(null, null, null));
+    }
+
     @Test
     public void shouldReturnSameObjectWhenAfterBodyReadCalled() {
         Object object = new Object();
@@ -85,27 +86,60 @@ public class EmrConditionControllerAdviceTest {
     }
 
     @Test
-    public void shouldProcessHttpInputMessageBeforeReturning() throws IOException {
-        HttpInputMessage httpInputMessage = createMockHttpInputMessage();
-        org.openmrs.module.emrapi.conditionslist.contract.Condition[] conditionList = createMockConditionList();
-        when(conditionConceptSaveService.update(any())).thenReturn(conditionList[0]);
+    public void shouldCallUpdateOnServiceWhenConditionWithCodedConceptProvided() throws IOException {
+        String bodyJson = "{\"condition\":{\"coded\":\"concept-uuid-123\"},\"patient\":\"patient-uuid\"}";
+        HttpInputMessage httpInputMessage = buildInputMessage(bodyJson);
+
+        when(conditionConceptSaveService.update(any(Condition.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
         emrConditionControllerAdvice.beforeBodyRead(httpInputMessage, null, null, null);
-        verify(conditionConceptSaveService, times(1)).update(any(org.openmrs.module.emrapi.conditionslist.contract.Condition.class));
+
+        verify(conditionConceptSaveService, times(1)).update(any(Condition.class));
     }
 
-    private HttpInputMessage createMockHttpInputMessage() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        org.openmrs.module.emrapi.conditionslist.contract.Condition[] conditions = createMockConditionList();
-        return new MappingJacksonInputMessage(new ByteArrayInputStream(objectMapper.writeValueAsString(conditions).getBytes()), new HttpHeaders());
-    }
-    private org.openmrs.module.emrapi.conditionslist.contract.Condition[] createMockConditionList() {
-        org.openmrs.module.emrapi.conditionslist.contract.Condition[] conditionList = new org.openmrs.module.emrapi.conditionslist.contract.Condition[1];
-        Condition condition = new Condition();
-        conditionList[0] = condition;
-        return conditionList;
+    @Test
+    public void shouldNotCallUpdateOnServiceWhenNoConditionFieldPresent() throws IOException {
+        String bodyJson = "{\"patient\":\"patient-uuid\",\"clinicalStatus\":\"ACTIVE\"}";
+        HttpInputMessage httpInputMessage = buildInputMessage(bodyJson);
+
+        emrConditionControllerAdvice.beforeBodyRead(httpInputMessage, null, null, null);
+
+        verify(conditionConceptSaveService, times(0)).update(any(Condition.class));
     }
 
+    @Test
+    public void shouldNotCallUpdateOnServiceWhenConditionHasNoCodedValue() throws IOException {
+        String bodyJson = "{\"condition\":{\"nonCoded\":\"some text\"},\"patient\":\"patient-uuid\"}";
+        HttpInputMessage httpInputMessage = buildInputMessage(bodyJson);
 
+        emrConditionControllerAdvice.beforeBodyRead(httpInputMessage, null, null, null);
 
+        verify(conditionConceptSaveService, times(0)).update(any(Condition.class));
+    }
+
+    @Test
+    public void shouldPassCorrectCodedUuidToService() throws IOException {
+        String conceptUuid = "snomed-concept-uuid-456";
+        String bodyJson = "{\"condition\":{\"coded\":\"" + conceptUuid + "\"},\"patient\":\"patient-uuid\"}";
+        HttpInputMessage httpInputMessage = buildInputMessage(bodyJson);
+
+        when(conditionConceptSaveService.update(any(Condition.class))).thenAnswer(invocation -> {
+            Condition c = invocation.getArgument(0);
+            assertEquals(conceptUuid, c.getCondition().getCoded().getUuid());
+            return c;
+        });
+
+        emrConditionControllerAdvice.beforeBodyRead(httpInputMessage, null, null, null);
+    }
+
+    private void setRequestContext(String method, String uri) {
+        HttpServletRequest request = org.mockito.Mockito.mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn(method);
+        when(request.getRequestURI()).thenReturn(uri);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+
+    private HttpInputMessage buildInputMessage(String json) {
+        return new MappingJacksonInputMessage(new ByteArrayInputStream(json.getBytes()), new HttpHeaders());
+    }
 }

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -55,14 +55,6 @@
             <artifactId>webservices.rest-omod-common</artifactId>
             <scope>provided</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.openmrs.module</groupId>-->
-<!--            <artifactId>emrapi-api</artifactId>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.openmrs.module</groupId>-->
-<!--            <artifactId>emrapi-web-2.2</artifactId>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -87,10 +79,6 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.openmrs.module</groupId>-->
-<!--            <artifactId>emrapi-condition-list</artifactId>-->
-<!--        </dependency>-->
     </dependencies>
 
     <build>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -45,10 +45,6 @@
             <artifactId>fhir2-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.openmrs.module</groupId>
-            <artifactId>emrapi-web-2.2</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.0.1</version>
@@ -59,10 +55,14 @@
             <artifactId>webservices.rest-omod-common</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.openmrs.module</groupId>
-            <artifactId>emrapi-api</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.openmrs.module</groupId>-->
+<!--            <artifactId>emrapi-api</artifactId>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.openmrs.module</groupId>-->
+<!--            <artifactId>emrapi-web-2.2</artifactId>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -87,10 +87,10 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.openmrs.module</groupId>
-            <artifactId>emrapi-condition-list</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.openmrs.module</groupId>-->
+<!--            <artifactId>emrapi-condition-list</artifactId>-->
+<!--        </dependency>-->
     </dependencies>
 
     <build>
@@ -131,7 +131,7 @@
                             <includeGroupIds>${project.parent.groupId}</includeGroupIds>
                             <includeArtifactIds>${project.parent.artifactId}-api</includeArtifactIds>
                             <excludeTransitive>true</excludeTransitive>
-                            <includes>**/*</includes>
+                            <includes>**/*.xml,**/*.properties</includes>
                             <outputDirectory>${project.build.directory}/classes</outputDirectory>
                         </configuration>
                     </execution>

--- a/omod/src/main/java/org/bahmni/module/fhirterminologyservices/web/filter/FhirEncounterBundleFilter.java
+++ b/omod/src/main/java/org/bahmni/module/fhirterminologyservices/web/filter/FhirEncounterBundleFilter.java
@@ -1,0 +1,176 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://www.bahmni.org/license/mplv2hd.
+ *
+ * Copyright 2026. SNOMED International. SNOMED International is a registered trademark
+ * and the SNOMED International graphic logo is a trademark of SNOMED International.
+ */
+
+package org.bahmni.module.fhirterminologyservices.web.filter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.bahmni.module.fhirterminologyservices.api.ConditionConceptSaveService;
+import org.openmrs.CodedOrFreeText;
+import org.openmrs.Concept;
+import org.openmrs.api.context.Context;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+
+public class FhirEncounterBundleFilter implements Filter {
+
+    private static final Logger logger = Logger.getLogger(FhirEncounterBundleFilter.class);
+    private static final String SNOMED_SYSTEM = "http://snomed.info/sct";
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {}
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        if ("POST".equals(httpRequest.getMethod())
+                && httpRequest.getRequestURI().contains("/ws/fhir2/R4/EncounterBundle")) {
+            String body = IOUtils.toString(httpRequest.getInputStream(), Charset.forName("UTF-8"));
+            String modifiedBody = resolveTerminologyCodes(body);
+            chain.doFilter(wrapWithBody(httpRequest, modifiedBody), response);
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void destroy() {}
+
+    @SuppressWarnings("unchecked")
+    private String resolveTerminologyCodes(String body) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            Map<String, Object> bundleMap = objectMapper.readValue(body, new TypeReference<Map<String, Object>>() {});
+            List<Map<String, Object>> entries = (List<Map<String, Object>>) bundleMap.get("entry");
+            if (entries == null) return body;
+
+            ConditionConceptSaveService saveService = getConditionConceptSaveService();
+            if (saveService == null) {
+                logger.warn("ConditionConceptSaveService unavailable, skipping SNOMED resolution for EncounterBundle");
+                return body;
+            }
+
+            for (Map<String, Object> entry : entries) {
+                Map<String, Object> resource = (Map<String, Object>) entry.get("resource");
+                if (resource == null) continue;
+
+                String resourceType = (String) resource.get("resourceType");
+                if ("Observation".equals(resourceType)) {
+                    resolveObservationValueConcept(resource, saveService);
+                } else if ("Condition".equals(resourceType)) {
+                    resolveConditionCodeConcept(resource, saveService);
+                }
+            }
+            return objectMapper.writeValueAsString(bundleMap);
+        } catch (Exception e) {
+            logger.error("Error resolving SNOMED codes in EncounterBundle, passing original body: " + e.getMessage());
+            return body;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void resolveObservationValueConcept(Map<String, Object> resource, ConditionConceptSaveService saveService) {
+        Map<String, Object> valueCodeableConcept = (Map<String, Object>) resource.get("valueCodeableConcept");
+        if (valueCodeableConcept == null) return;
+        List<Map<String, Object>> codings = (List<Map<String, Object>>) valueCodeableConcept.get("coding");
+        if (codings == null) return;
+
+        for (Map<String, Object> coding : codings) {
+            if (coding.containsKey("system")) continue;
+            Object codeObj = coding.get("code");
+            if (codeObj == null) continue;
+
+            String code = codeObj.toString();
+            int lastSlash = code.lastIndexOf("/");
+            if (lastSlash < 0) continue;
+
+            // code is a full URL e.g. "http://snomed.info/sct/225057002"
+            String conceptSystem = code.substring(0, lastSlash);
+            String conceptCode = code.substring(lastSlash + 1);
+            ensureConceptExists(code, saveService);
+            coding.put("system", conceptSystem);
+            coding.put("code", conceptCode);
+            logger.info("Resolved Observation valueCoded: " + code + " → system=" + conceptSystem + " code=" + conceptCode);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void resolveConditionCodeConcept(Map<String, Object> resource, ConditionConceptSaveService saveService) {
+        Map<String, Object> codeElement = (Map<String, Object>) resource.get("code");
+        if (codeElement == null) return;
+        List<Map<String, Object>> codings = (List<Map<String, Object>>) codeElement.get("coding");
+        if (codings == null) return;
+
+        for (Map<String, Object> coding : codings) {
+            if (coding.containsKey("system")) continue;
+            Object codeObj = coding.get("code");
+            if (codeObj == null) continue;
+
+            String code = codeObj.toString();
+            if (!code.matches("\\d+")) continue;
+
+            // bare SNOMED code e.g. "283111009" — construct full URL for resolution
+            String fullSnomedUrl = SNOMED_SYSTEM + "/" + code;
+            ensureConceptExists(fullSnomedUrl, saveService);
+            coding.put("system", SNOMED_SYSTEM);
+            logger.info("Resolved Condition code: " + code + " → system=" + SNOMED_SYSTEM);
+        }
+    }
+
+    private void ensureConceptExists(String snomedUrl, ConditionConceptSaveService saveService) {
+        try {
+            Concept codedConcept = new Concept();
+            codedConcept.setUuid(snomedUrl);
+            CodedOrFreeText codedOrFreeText = new CodedOrFreeText();
+            codedOrFreeText.setCoded(codedConcept);
+            org.openmrs.Condition condition = new org.openmrs.Condition();
+            condition.setCondition(codedOrFreeText);
+            saveService.update(condition);
+        } catch (Exception e) {
+            logger.error("Failed to ensure concept exists for SNOMED URL: " + snomedUrl + " — " + e.getMessage());
+        }
+    }
+
+    private ConditionConceptSaveService getConditionConceptSaveService() {
+        try {
+            List<ConditionConceptSaveService> services = Context.getRegisteredComponents(ConditionConceptSaveService.class);
+            return services.isEmpty() ? null : services.get(0);
+        } catch (Exception e) {
+            logger.warn("Could not get ConditionConceptSaveService: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private HttpServletRequestWrapper wrapWithBody(HttpServletRequest request, String body) {
+        byte[] bodyBytes = body.getBytes(Charset.forName("UTF-8"));
+        return new HttpServletRequestWrapper(request) {
+            @Override
+            public ServletInputStream getInputStream() {
+                final InputStream is = new ByteArrayInputStream(bodyBytes);
+                return new ServletInputStream() {
+                    @Override
+                    public int read() throws IOException { return is.read(); }
+                };
+            }
+            @Override
+            public BufferedReader getReader() {
+                return new BufferedReader(new InputStreamReader(getInputStream()));
+            }
+        };
+    }
+}

--- a/omod/src/main/java/org/bahmni/module/fhirterminologyservices/web/filter/FhirEncounterBundleFilter.java
+++ b/omod/src/main/java/org/bahmni/module/fhirterminologyservices/web/filter/FhirEncounterBundleFilter.java
@@ -22,7 +22,6 @@ import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import java.io.*;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
@@ -40,9 +39,9 @@ public class FhirEncounterBundleFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         if ("POST".equals(httpRequest.getMethod())
                 && httpRequest.getRequestURI().contains("/ws/fhir2/R4/EncounterBundle")) {
-            String body = IOUtils.toString(httpRequest.getInputStream(), Charset.forName("UTF-8"));
-            String modifiedBody = resolveTerminologyCodes(body);
-            chain.doFilter(wrapWithBody(httpRequest, modifiedBody), response);
+            byte[] bodyBytes = IOUtils.toByteArray(httpRequest.getInputStream());
+            ensureSnomedConceptsExist(bodyBytes);
+            chain.doFilter(wrapWithBody(httpRequest, bodyBytes), response);
         } else {
             chain.doFilter(request, response);
         }
@@ -52,83 +51,41 @@ public class FhirEncounterBundleFilter implements Filter {
     public void destroy() {}
 
     @SuppressWarnings("unchecked")
-    private String resolveTerminologyCodes(String body) {
+    private void ensureSnomedConceptsExist(byte[] bodyBytes) {
         try {
             ObjectMapper objectMapper = new ObjectMapper();
-            Map<String, Object> bundleMap = objectMapper.readValue(body, new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> bundleMap = objectMapper.readValue(bodyBytes, new TypeReference<Map<String, Object>>() {});
             List<Map<String, Object>> entries = (List<Map<String, Object>>) bundleMap.get("entry");
-            if (entries == null) return body;
+            if (entries == null) return;
 
             ConditionConceptSaveService saveService = getConditionConceptSaveService();
             if (saveService == null) {
-                logger.warn("ConditionConceptSaveService unavailable, skipping SNOMED resolution for EncounterBundle");
-                return body;
+                logger.warn("ConditionConceptSaveService unavailable, skipping SNOMED concept creation for EncounterBundle");
+                return;
             }
 
             for (Map<String, Object> entry : entries) {
                 Map<String, Object> resource = (Map<String, Object>) entry.get("resource");
                 if (resource == null) continue;
+                if (!"Observation".equals(resource.get("resourceType"))) continue;
 
-                String resourceType = (String) resource.get("resourceType");
-                if ("Observation".equals(resourceType)) {
-                    resolveObservationValueConcept(resource, saveService);
-                } else if ("Condition".equals(resourceType)) {
-                    resolveConditionCodeConcept(resource, saveService);
+                Map<String, Object> valueCodeableConcept = (Map<String, Object>) resource.get("valueCodeableConcept");
+                if (valueCodeableConcept == null) continue;
+                List<Map<String, Object>> codings = (List<Map<String, Object>>) valueCodeableConcept.get("coding");
+                if (codings == null) continue;
+
+                for (Map<String, Object> coding : codings) {
+                    Object system = coding.get("system");
+                    Object code = coding.get("code");
+                    if (system == null || code == null) continue;
+                    if (!SNOMED_SYSTEM.equals(system.toString())) continue;
+
+                    ensureConceptExists(system + "/" + code, saveService);
+                    logger.info("Ensured SNOMED concept exists: system=" + system + " code=" + code);
                 }
             }
-            return objectMapper.writeValueAsString(bundleMap);
         } catch (Exception e) {
-            logger.error("Error resolving SNOMED codes in EncounterBundle, passing original body: " + e.getMessage());
-            return body;
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private void resolveObservationValueConcept(Map<String, Object> resource, ConditionConceptSaveService saveService) {
-        Map<String, Object> valueCodeableConcept = (Map<String, Object>) resource.get("valueCodeableConcept");
-        if (valueCodeableConcept == null) return;
-        List<Map<String, Object>> codings = (List<Map<String, Object>>) valueCodeableConcept.get("coding");
-        if (codings == null) return;
-
-        for (Map<String, Object> coding : codings) {
-            if (coding.containsKey("system")) continue;
-            Object codeObj = coding.get("code");
-            if (codeObj == null) continue;
-
-            String code = codeObj.toString();
-            int lastSlash = code.lastIndexOf("/");
-            if (lastSlash < 0) continue;
-
-            // code is a full URL e.g. "http://snomed.info/sct/225057002"
-            String conceptSystem = code.substring(0, lastSlash);
-            String conceptCode = code.substring(lastSlash + 1);
-            ensureConceptExists(code, saveService);
-            coding.put("system", conceptSystem);
-            coding.put("code", conceptCode);
-            logger.info("Resolved Observation valueCoded: " + code + " → system=" + conceptSystem + " code=" + conceptCode);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private void resolveConditionCodeConcept(Map<String, Object> resource, ConditionConceptSaveService saveService) {
-        Map<String, Object> codeElement = (Map<String, Object>) resource.get("code");
-        if (codeElement == null) return;
-        List<Map<String, Object>> codings = (List<Map<String, Object>>) codeElement.get("coding");
-        if (codings == null) return;
-
-        for (Map<String, Object> coding : codings) {
-            if (coding.containsKey("system")) continue;
-            Object codeObj = coding.get("code");
-            if (codeObj == null) continue;
-
-            String code = codeObj.toString();
-            if (!code.matches("\\d+")) continue;
-
-            // bare SNOMED code e.g. "283111009" — construct full URL for resolution
-            String fullSnomedUrl = SNOMED_SYSTEM + "/" + code;
-            ensureConceptExists(fullSnomedUrl, saveService);
-            coding.put("system", SNOMED_SYSTEM);
-            logger.info("Resolved Condition code: " + code + " → system=" + SNOMED_SYSTEM);
+            logger.error("Error during SNOMED concept creation for EncounterBundle, proceeding with original body: " + e.getMessage());
         }
     }
 
@@ -156,8 +113,7 @@ public class FhirEncounterBundleFilter implements Filter {
         }
     }
 
-    private HttpServletRequestWrapper wrapWithBody(HttpServletRequest request, String body) {
-        byte[] bodyBytes = body.getBytes(Charset.forName("UTF-8"));
+    private HttpServletRequestWrapper wrapWithBody(HttpServletRequest request, final byte[] bodyBytes) {
         return new HttpServletRequestWrapper(request) {
             @Override
             public ServletInputStream getInputStream() {

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -102,5 +102,14 @@
 
     <!-- AOP -->
     <!-- Required Privileges -->
+
+    <filter>
+        <filter-name>fhirEncounterBundleFilter</filter-name>
+        <filter-class>org.bahmni.module.fhirterminologyservices.web.filter.FhirEncounterBundleFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>fhirEncounterBundleFilter</filter-name>
+        <url-pattern>/ws/fhir2/R4/EncounterBundle</url-pattern>
+    </filter-mapping>
 </module>
 

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -111,5 +111,6 @@
         <filter-name>fhirEncounterBundleFilter</filter-name>
         <url-pattern>/ws/fhir2/R4/EncounterBundle</url-pattern>
     </filter-mapping>
+
 </module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -241,42 +241,6 @@
                 <version>${bahmniCoreVersion}</version>
                 <scope>provided</scope>
             </dependency>
-<!--            <dependency>-->
-<!--                <groupId>org.openmrs.module</groupId>-->
-<!--                <artifactId>emrapi-api-1.12</artifactId>-->
-<!--                <version>${emrapiLegacyVersion}</version>-->
-<!--                <scope>provided</scope>-->
-<!--                <exclusions>-->
-<!--                    <exclusion>-->
-<!--                        <groupId>org.hamcrest</groupId>-->
-<!--                        <artifactId>hamcrest-library</artifactId>-->
-<!--                    </exclusion>-->
-<!--                </exclusions>-->
-<!--            </dependency>-->
-<!--            <dependency>-->
-<!--                <groupId>org.openmrs.module</groupId>-->
-<!--                <artifactId>emrapi-condition-list</artifactId>-->
-<!--                <version>${emrapiLegacyVersion}</version>-->
-<!--                <scope>provided</scope>-->
-<!--                <exclusions>-->
-<!--                    <exclusion>-->
-<!--                        <groupId>org.hamcrest</groupId>-->
-<!--                        <artifactId>hamcrest-library</artifactId>-->
-<!--                    </exclusion>-->
-<!--                </exclusions>-->
-<!--            </dependency>-->
-<!--            <dependency>-->
-<!--                <groupId>org.openmrs.module</groupId>-->
-<!--                <artifactId>emrapi-web-2.2</artifactId>-->
-<!--                <version>${emrapiLegacyVersion}</version>-->
-<!--                <scope>provided</scope>-->
-<!--                <exclusions>-->
-<!--                    <exclusion>-->
-<!--                        <groupId>org.hamcrest</groupId>-->
-<!--                        <artifactId>hamcrest-library</artifactId>-->
-<!--                    </exclusion>-->
-<!--                </exclusions>-->
-<!--            </dependency>-->
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>emrapi-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,18 +26,19 @@
         </developer>
     </developers>
     <properties>
-        <openmrsPlatformVersion>2.5.12</openmrsPlatformVersion>
+        <openmrsPlatformVersion>2.6.15</openmrsPlatformVersion>
+        <springVersion>5.3.23</springVersion>
         <powerMockVersion>2.0.9</powerMockVersion>
         <mockitoVersion>3.5.11</mockitoVersion>
         <junitVersion>4.13.1</junitVersion>
-        <webServicesVersion>2.44.0</webServicesVersion>
+        <webServicesVersion>2.50.0</webServicesVersion>
         <jacocoVersion>0.8.3</jacocoVersion>
-        <openmrsFhir2Version>2.1.0</openmrsFhir2Version>
+        <openmrsFhir2Version>3.0.0</openmrsFhir2Version>
         <commonsLang3Version>3.12.0</commonsLang3Version>
         <jenaArqVersion>4.7.0</jenaArqVersion>
-        <emrapiVersion>1.36.0</emrapiVersion>
-        <metadatamappingVersion>1.6.0</metadatamappingVersion>
-        <bahmniCoreVersion>1.2.0</bahmniCoreVersion>
+        <emrapiVersion>2.4.0</emrapiVersion>
+        <metadatamappingVersion>2.0.0</metadatamappingVersion>
+        <bahmniCoreVersion>2.0.0-SNAPSHOT</bahmniCoreVersion>
     </properties>
     <scm>
         <connection>scm:git:git://github.com/bahmni/openmrs-module-snomed.git</connection>
@@ -240,45 +241,45 @@
                 <version>${bahmniCoreVersion}</version>
                 <scope>provided</scope>
             </dependency>
+<!--            <dependency>-->
+<!--                <groupId>org.openmrs.module</groupId>-->
+<!--                <artifactId>emrapi-api-1.12</artifactId>-->
+<!--                <version>${emrapiLegacyVersion}</version>-->
+<!--                <scope>provided</scope>-->
+<!--                <exclusions>-->
+<!--                    <exclusion>-->
+<!--                        <groupId>org.hamcrest</groupId>-->
+<!--                        <artifactId>hamcrest-library</artifactId>-->
+<!--                    </exclusion>-->
+<!--                </exclusions>-->
+<!--            </dependency>-->
+<!--            <dependency>-->
+<!--                <groupId>org.openmrs.module</groupId>-->
+<!--                <artifactId>emrapi-condition-list</artifactId>-->
+<!--                <version>${emrapiLegacyVersion}</version>-->
+<!--                <scope>provided</scope>-->
+<!--                <exclusions>-->
+<!--                    <exclusion>-->
+<!--                        <groupId>org.hamcrest</groupId>-->
+<!--                        <artifactId>hamcrest-library</artifactId>-->
+<!--                    </exclusion>-->
+<!--                </exclusions>-->
+<!--            </dependency>-->
+<!--            <dependency>-->
+<!--                <groupId>org.openmrs.module</groupId>-->
+<!--                <artifactId>emrapi-web-2.2</artifactId>-->
+<!--                <version>${emrapiLegacyVersion}</version>-->
+<!--                <scope>provided</scope>-->
+<!--                <exclusions>-->
+<!--                    <exclusion>-->
+<!--                        <groupId>org.hamcrest</groupId>-->
+<!--                        <artifactId>hamcrest-library</artifactId>-->
+<!--                    </exclusion>-->
+<!--                </exclusions>-->
+<!--            </dependency>-->
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>emrapi-api</artifactId>
-                <version>${emrapiVersion}</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-library</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>emrapi-api-1.12</artifactId>
-                <version>${emrapiVersion}</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-library</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>emrapi-condition-list</artifactId>
-                <version>${emrapiVersion}</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-library</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>emrapi-web-2.2</artifactId>
                 <version>${emrapiVersion}</version>
                 <scope>provided</scope>
                 <exclusions>


### PR DESCRIPTION
 https://bahmni.atlassian.net/browse/BAH-4811

Summary                                                                                                                                                                                                        
                                                                                                                                                                                                                 
  Upgrades the openmrs-module-snomed module to be compatible with OpenMRS platform 2.6.x and its updated dependency stack, removing the legacy emrapi condition model in favour of the core OpenMRS Condition    
  API.                                                                                                                                                                                                           
                                                                                                                                                                                                                 
  Version bumps:                                                                                                                                                                                                 
  - OpenMRS platform: 2.5.12 → 2.6.15                                                                                                                                                                            
  - emrapi: 1.36.0 → 2.4.0                                                                                                                                                                                       
  - openmrs-fhir2: 2.1.0 → 3.0.0                                                                                                                                                                                 
  - webservices.rest: 2.44.0 → 2.50.0                                                                                                                                                                            
  - metadatamapping: 1.6.0 → 2.0.0                                                                                                                                                                               
  - bahmni-core: 1.2.0 → 2.0.0-SNAPSHOT                                                                                                                                                                          
                                                                                                                                                                                                                 
  Breaking dependency removals:                                                                                                                                                                                  
  - Dropped emrapi-api-1.12, emrapi-condition-list, and emrapi-web-2.2 which no longer exist in emrapi 2.x                                                                                                       
                                                                                                                                                                                                                 
  Condition model migration:                                                                                                                                                                                     
  - Replaced org.openmrs.module.emrapi.conditionslist.contract.Condition/Concept with org.openmrs.Condition and org.openmrs.Concept across ConditionConceptSaveService, ConditionConceptSaveImpl,                
  TSConceptUuidResolver, and EmrConditionControllerAdvice                                                                                                                                                        
                                                                                                                                                                                                                 
  EmrConditionControllerAdvice refactor:                                                                                                                                                                         
  - Now intercepts MainResourceController instead of the removed ConditionController                                                                                                                             
  - supports() checks HTTP method and URI (POST /ws/rest/v1/condition) instead of method name                                                                                                                    
  - Body parsing updated to handle the REST v1 condition payload format (single object map vs. array)                                                                                                            
                                                                                                                                                                                                                 
  New FhirEncounterBundleFilter:                                                                                                                                                                                 
  - Servlet filter on POST /ws/fhir2/R4/EncounterBundle that inspects FHIR Observation entries and ensures any SNOMED-coded concepts exist in OpenMRS before the bundle is processed                             
                                                                                                                                                                                                                 
  Other fixes:                                                                                                                                                                                                   
  - Disabled FHIR server capability validation on startup (ServerValidationModeEnum.NEVER) to prevent connection errors during initialisation                                                                    
  - Replaced PowerMock with standard Mockito in EmrConditionControllerAdviceTest                                                                                                                                 
  - Fixed Maven resource filtering to exclude binary files (**/*.xml,**/*.properties)                                                                                                                            
  - Updated Spring beans schema reference to version-agnostic spring-beans.xsd